### PR TITLE
Added immediate send functionality

### DIFF
--- a/app/src/main/java/com/vmware/herald/app/AppDelegate.java
+++ b/app/src/main/java/com/vmware/herald/app/AppDelegate.java
@@ -11,6 +11,7 @@ import android.util.Log;
 import com.vmware.herald.sensor.Sensor;
 import com.vmware.herald.sensor.SensorArray;
 import com.vmware.herald.sensor.SensorDelegate;
+import com.vmware.herald.sensor.datatype.ImmediateSendData;
 import com.vmware.herald.sensor.datatype.Location;
 import com.vmware.herald.sensor.datatype.PayloadData;
 import com.vmware.herald.sensor.datatype.Proximity;
@@ -75,6 +76,11 @@ public class AppDelegate extends Application implements SensorDelegate {
     @Override
     public void sensor(SensorType sensor, PayloadData didRead, TargetIdentifier fromTarget) {
         Log.i(tag, sensor.name() + ",didRead=" + didRead.shortName() + ",fromTarget=" + fromTarget);
+    }
+
+    @Override
+    public void sensor(SensorType sensor, ImmediateSendData didReceive, TargetIdentifier fromTarget) {
+        Log.i(tag, sensor.name() + ",didReceive=" + didReceive.data.base64EncodedString() + ",fromTarget=" + fromTarget);
     }
 
     @Override

--- a/app/src/main/java/com/vmware/herald/app/MainActivity.java
+++ b/app/src/main/java/com/vmware/herald/app/MainActivity.java
@@ -17,6 +17,7 @@ import androidx.core.app.ActivityCompat;
 
 import com.vmware.herald.sensor.SensorArray;
 import com.vmware.herald.sensor.SensorDelegate;
+import com.vmware.herald.sensor.datatype.ImmediateSendData;
 import com.vmware.herald.sensor.datatype.Location;
 import com.vmware.herald.sensor.datatype.PayloadData;
 import com.vmware.herald.sensor.datatype.Proximity;
@@ -42,7 +43,7 @@ public class MainActivity extends AppCompatActivity implements SensorDelegate {
     private final static int permissionRequestCode = 1249951875;
     /// Test UI specific data, not required for production solution.
     private final static SimpleDateFormat dateFormatter = new SimpleDateFormat("MMdd HH:mm:ss");
-    private long didDetect = 0, didRead = 0, didMeasure = 0, didShare = 0, didVisit = 0;
+    private long didDetect = 0, didRead = 0, didReceive = 0, didMeasure = 0, didShare = 0, didVisit = 0;
     private final Map<TargetIdentifier, String> payloads = new ConcurrentHashMap<>();
     private final Map<String, Date> didReadPayloads = new ConcurrentHashMap<>();
     private final Map<String, Date> didSharePayloads = new ConcurrentHashMap<>();
@@ -180,6 +181,22 @@ public class MainActivity extends AppCompatActivity implements SensorDelegate {
                 updateDetection();
             }
         });
+    }
+
+    @Override
+    public void sensor(SensorType sensor, ImmediateSendData didReceive, TargetIdentifier fromTarget) {
+        this.didReceive++;
+        // TODO expose received immediate send data on the demo UI
+//        final String timestamp = dateFormatter.format(new Date());
+//        final String text = "didReceive: " + this.didReceive + " (" + timestamp + ")";
+//        runOnUiThread(new Runnable() {
+//            @Override
+//            public void run() {
+//                final TextView textView = findViewById(R.id.didReceive);
+//                textView.setText(text);
+//                updateDetection();
+//            }
+//        });
     }
 
     @Override

--- a/herald/src/main/java/com/vmware/herald/sensor/DefaultSensorDelegate.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/DefaultSensorDelegate.java
@@ -4,6 +4,7 @@
 
 package com.vmware.herald.sensor;
 
+import com.vmware.herald.sensor.datatype.ImmediateSendData;
 import com.vmware.herald.sensor.datatype.Location;
 import com.vmware.herald.sensor.datatype.PayloadData;
 import com.vmware.herald.sensor.datatype.Proximity;
@@ -22,6 +23,10 @@ public abstract class DefaultSensorDelegate implements SensorDelegate {
 
     @Override
     public void sensor(SensorType sensor, PayloadData didRead, TargetIdentifier fromTarget) {
+    }
+
+    @Override
+    public void sensor(SensorType sensor, ImmediateSendData didReceive, TargetIdentifier fromTarget) {
     }
 
     @Override

--- a/herald/src/main/java/com/vmware/herald/sensor/Sensor.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/Sensor.java
@@ -4,6 +4,9 @@
 
 package com.vmware.herald.sensor;
 
+import com.vmware.herald.sensor.datatype.Data;
+import com.vmware.herald.sensor.datatype.TargetIdentifier;
+
 /// Sensor for detecting and tracking various kinds of disease transmission vectors, e.g. contact with people, time at location.
 public interface Sensor {
     /// Add delegate for responding to sensor events.

--- a/herald/src/main/java/com/vmware/herald/sensor/SensorDelegate.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/SensorDelegate.java
@@ -4,6 +4,7 @@
 
 package com.vmware.herald.sensor;
 
+import com.vmware.herald.sensor.datatype.ImmediateSendData;
 import com.vmware.herald.sensor.datatype.Location;
 import com.vmware.herald.sensor.datatype.PayloadData;
 import com.vmware.herald.sensor.datatype.Proximity;
@@ -20,6 +21,9 @@ public interface SensorDelegate {
 
     /// Read payload data from target, e.g. encrypted device identifier from BLE peripheral after successful connection.
     void sensor(SensorType sensor, PayloadData didRead, TargetIdentifier fromTarget);
+
+    /// Receive written immediate send data from target, e.g. important timing signal.
+    void sensor(SensorType sensor, ImmediateSendData didReceive, TargetIdentifier fromTarget);
 
     /// Read payload data of other targets recently acquired by a target, e.g. Android peripheral sharing payload data acquired from nearby iOS peripherals.
     void sensor(SensorType sensor, List<PayloadData> didShare, TargetIdentifier fromTarget);

--- a/herald/src/main/java/com/vmware/herald/sensor/ble/BLEDatabase.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/ble/BLEDatabase.java
@@ -27,6 +27,9 @@ public interface BLEDatabase {
     /// Get or create device for collating information from asynchronous BLE operations.
     BLEDevice device(PayloadData payloadData);
 
+    /// Get a device from a TargetIdentifier
+    BLEDevice device(TargetIdentifier targetIdentifier);
+
     /// Get all devices
     List<BLEDevice> devices();
 

--- a/herald/src/main/java/com/vmware/herald/sensor/ble/BLEReceiver.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/ble/BLEReceiver.java
@@ -6,6 +6,8 @@ package com.vmware.herald.sensor.ble;
 
 import com.vmware.herald.sensor.Sensor;
 import com.vmware.herald.sensor.SensorDelegate;
+import com.vmware.herald.sensor.datatype.Data;
+import com.vmware.herald.sensor.datatype.TargetIdentifier;
 
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -15,4 +17,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
  */
 public interface BLEReceiver extends Sensor {
     Queue<SensorDelegate> delegates = new ConcurrentLinkedQueue<>();
+
+    /// Immediate send data.
+    boolean immediateSend(Data data, TargetIdentifier targetIdentifier);
 }

--- a/herald/src/main/java/com/vmware/herald/sensor/ble/BLESensorConfiguration.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/ble/BLESensorConfiguration.java
@@ -38,6 +38,8 @@ public class BLESensorConfiguration {
     public final static byte signalCharacteristicActionWriteRSSI = (byte) 2;
     /// Signal characteristic action code for write payload, expect 1 byte action code followed by 2 byte little-endian Int16 integer value for payload sharing data length, then payload sharing data
     public final static byte signalCharacteristicActionWritePayloadSharing = (byte) 3;
+    /// Arbitrary immediate write
+    public final static byte signalCharacteristicActionWriteImmediate = (byte) 4;
 
     // BLE advert manufacturer ID for Apple, for scanning of background iOS devices
     public final static int manufacturerIdForApple = 76;

--- a/herald/src/main/java/com/vmware/herald/sensor/ble/ConcreteBLEDatabase.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/ble/ConcreteBLEDatabase.java
@@ -174,6 +174,10 @@ public class ConcreteBLEDatabase implements BLEDatabase, BLEDeviceDelegate {
         return payloadData;
     }
 
+    @Override
+    public BLEDevice device(TargetIdentifier targetIdentifier) {
+        return database.get(targetIdentifier);
+    }
 
     @Override
     public BLEDevice device(BluetoothDevice bluetoothDevice) {

--- a/herald/src/main/java/com/vmware/herald/sensor/ble/ConcreteBLESensor.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/ble/ConcreteBLESensor.java
@@ -9,6 +9,7 @@ import android.content.Context;
 import com.vmware.herald.sensor.data.ConcreteSensorLogger;
 import com.vmware.herald.sensor.data.SensorLogger;
 import com.vmware.herald.sensor.datatype.BluetoothState;
+import com.vmware.herald.sensor.datatype.Data;
 import com.vmware.herald.sensor.datatype.PayloadData;
 import com.vmware.herald.sensor.datatype.Proximity;
 import com.vmware.herald.sensor.datatype.ProximityMeasurementUnit;
@@ -17,6 +18,7 @@ import com.vmware.herald.sensor.datatype.SensorState;
 import com.vmware.herald.sensor.datatype.SensorType;
 import com.vmware.herald.sensor.PayloadDataSupplier;
 import com.vmware.herald.sensor.SensorDelegate;
+import com.vmware.herald.sensor.datatype.TargetIdentifier;
 
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;

--- a/herald/src/main/java/com/vmware/herald/sensor/ble/ConcreteBLETransmitter.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/ble/ConcreteBLETransmitter.java
@@ -25,6 +25,7 @@ import com.vmware.herald.sensor.data.SensorLogger;
 import com.vmware.herald.sensor.datatype.BluetoothState;
 import com.vmware.herald.sensor.datatype.Callback;
 import com.vmware.herald.sensor.datatype.Data;
+import com.vmware.herald.sensor.datatype.ImmediateSendData;
 import com.vmware.herald.sensor.datatype.PayloadData;
 import com.vmware.herald.sensor.datatype.PayloadSharingData;
 import com.vmware.herald.sensor.datatype.PayloadTimestamp;
@@ -459,6 +460,18 @@ public class ConcreteBLETransmitter implements BLETransmitter, BluetoothStateMan
                             sharedDevice.operatingSystem(BLEDeviceOperatingSystem.shared);
                             sharedDevice.rssi(payloadSharingData.rssi);
                         }
+                        break;
+                    }
+                    case immediateSend: {
+                        final ImmediateSendData immediateSendData = SignalCharacteristicData.decodeImmediateSend(data);
+                        if (immediateSendData == null) {
+                            // Fragmented immediate send data may be incomplete
+                            break;
+                        }
+                        for (SensorDelegate delegate : delegates) {
+                            delegate.sensor(SensorType.BLE, immediateSendData, targetIdentifier);
+                        }
+                        logger.debug("didReceiveWrite (dataType=immediateSend,central={},immediateSendData={})", targetDevice, immediateSendData.data);
                         break;
                     }
                 }

--- a/herald/src/main/java/com/vmware/herald/sensor/datatype/ImmediateSendData.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/datatype/ImmediateSendData.java
@@ -1,0 +1,18 @@
+//  Copyright 2020 VMware, Inc.
+//  SPDX-License-Identifier: MIT
+//
+
+package com.vmware.herald.sensor.datatype;
+
+public class ImmediateSendData {
+    public final Data data;
+
+    /**
+     * Immediate Send data
+     *
+     * @param data Data being send using immediateSend (app specific format).
+     */
+    public ImmediateSendData(final Data data) {
+        this.data = data;
+    }
+}

--- a/herald/src/main/java/com/vmware/herald/sensor/datatype/SignalCharacteristicData.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/datatype/SignalCharacteristicData.java
@@ -119,6 +119,43 @@ public class SignalCharacteristicData {
         return new PayloadSharingData(new RSSI(rssiValue.intValue()), payloadSharingDataBytes);
     }
 
+    /// Encode immediate send data bundle
+    // immediateSend data format
+    // 0-0 : actionCode
+    // 1-2 : payload data count in bytes (Int16)
+    // 3.. : payload data
+    public static Data encodeImmediateSend(final ImmediateSendData immediateSendData) {
+        final ByteBuffer byteBuffer = ByteBuffer.allocate(3 + immediateSendData.data.value.length);
+        byteBuffer.order(ByteOrder.LITTLE_ENDIAN);
+        byteBuffer.put(0, BLESensorConfiguration.signalCharacteristicActionWriteImmediate);
+        byteBuffer.putShort(1, (short) immediateSendData.data.value.length);
+        byteBuffer.position(3);
+        byteBuffer.put(immediateSendData.data.value);
+        return new Data(byteBuffer.array());
+    }
+
+    /// Decode immediate send data bundle
+    public static ImmediateSendData decodeImmediateSend(final Data data) {
+        if (signalDataActionCode(data.value) != BLESensorConfiguration.signalCharacteristicActionWriteImmediate) {
+            return null;
+        }
+        if (data.value.length < 3) {
+            return null;
+        }
+        final Short immediateSendDataCount = int16(data.value, 1);
+        if (immediateSendDataCount == null) {
+            return null;
+        }
+        if (data.value.length != (3 + immediateSendDataCount.intValue())) {
+            return null;
+        }
+        final Data immediateSendDataBytes = new Data(data.value).subdata(3);
+        if (immediateSendDataBytes == null) {
+            return null;
+        }
+        return new ImmediateSendData(immediateSendDataBytes);
+    }
+
     /// Detect signal characteristic data bundle type
     public static SignalCharacteristicDataType detect(Data data) {
         switch (signalDataActionCode(data.value)) {
@@ -128,6 +165,8 @@ public class SignalCharacteristicData {
                 return SignalCharacteristicDataType.payload;
             case BLESensorConfiguration.signalCharacteristicActionWritePayloadSharing:
                 return SignalCharacteristicDataType.payloadSharing;
+            case BLESensorConfiguration.signalCharacteristicActionWriteImmediate:
+                return SignalCharacteristicDataType.immediateSend;
             default:
                 return SignalCharacteristicDataType.unknown;
         }

--- a/herald/src/main/java/com/vmware/herald/sensor/datatype/SignalCharacteristicDataType.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/datatype/SignalCharacteristicDataType.java
@@ -5,5 +5,5 @@
 package com.vmware.herald.sensor.datatype;
 
 public enum SignalCharacteristicDataType {
-    rssi, payload, payloadSharing, unknown
+    rssi, payload, payloadSharing, immediateSend, unknown
 }


### PR DESCRIPTION
Fixes #7
- Adds BLEReceiver.immediateSend(Data)
- Connects if not already connected
- Disconnects after only if this function caused the connection
- Returns true if send was successful
- Added BLEDatabase.device(TargetIdentifier) too to bring in line with iOS API
Signed-off-by: Adam Fowler <adamfowleruk@gmail.com>