### PR TITLE
Configurable payload read - Validated

### DIFF
--- a/herald/src/main/java/com/vmware/herald/sensor/SensorArray.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/SensorArray.java
@@ -14,6 +14,7 @@ import com.vmware.herald.sensor.data.ConcreteSensorLogger;
 import com.vmware.herald.sensor.data.ContactLog;
 import com.vmware.herald.sensor.data.DetectionLog;
 import com.vmware.herald.sensor.data.SensorLogger;
+import com.vmware.herald.sensor.data.StatisticsDidReadLog;
 import com.vmware.herald.sensor.data.StatisticsLog;
 import com.vmware.herald.sensor.datatype.PayloadData;
 import com.vmware.herald.sensor.datatype.PayloadTimestamp;
@@ -53,6 +54,7 @@ public class SensorArray implements Sensor {
         payloadData = payloadDataSupplier.payload(new PayloadTimestamp());
         add(new ContactLog(context, "contacts.csv"));
         add(new StatisticsLog(context, "statistics.csv", payloadData));
+        add(new StatisticsDidReadLog(context, "statistics_didRead.csv", payloadData));
         add(new DetectionLog(context,"detection.csv", payloadData));
         new BatteryLog(context, "battery.csv");
 

--- a/herald/src/main/java/com/vmware/herald/sensor/analysis/Interactions.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/analysis/Interactions.java
@@ -1,0 +1,42 @@
+package com.vmware.herald.sensor.analysis;
+
+import android.content.Context;
+
+import com.vmware.herald.sensor.data.ConcreteSensorLogger;
+import com.vmware.herald.sensor.data.SensorLogger;
+import com.vmware.herald.sensor.data.TextFile;
+import com.vmware.herald.sensor.datatype.Encounter;
+
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.List;
+
+/// Log of interactions for recording encounters (time, proximity, and identity).
+/// This is can be used as basis for maintaining a persistent log
+/// of encounters for on-device or centralised matching.
+public class Interactions {
+    private final SensorLogger logger = new ConcreteSensorLogger("Sensor", "Analysis.EncounterLog");
+    private final TextFile textFile;
+    private final SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+    private final List<Encounter> encounters = new ArrayList<>();
+
+    public Interactions() {
+        textFile = null;
+    }
+
+    public Interactions(final Context context, final String filename) {
+        textFile = new TextFile(context, filename);
+        if (textFile.empty()) {
+            textFile.write("time,proximity,unit,payload");
+        } else {
+            final String content = textFile.contentsOf();
+            for (String line : content.split("\n")) {
+                final Encounter encounter = new Encounter(line);
+                if (encounter.isValid()) {
+                    encounters.add(encounter);
+                }
+            }
+            logger.debug("Loaded historic encounters (count={})", encounters.size());
+        }
+    }
+}

--- a/herald/src/main/java/com/vmware/herald/sensor/analysis/Interactions.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/analysis/Interactions.java
@@ -1,3 +1,7 @@
+//  Copyright 2020 VMware, Inc.
+//  SPDX-License-Identifier: MIT
+//
+
 package com.vmware.herald.sensor.analysis;
 
 import android.content.Context;

--- a/herald/src/main/java/com/vmware/herald/sensor/ble/BLEDevice.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/ble/BLEDevice.java
@@ -37,6 +37,7 @@ public class BLEDevice {
     private BLEDeviceOperatingSystem operatingSystem = BLEDeviceOperatingSystem.unknown;
     /// Payload data acquired from the device via payloadCharacteristic read, e.g. C19X beacon code or Sonar encrypted identifier
     private PayloadData payloadData;
+    private Date lastPayloadDataUpdate = null;
     /// Most recent RSSI measurement taken by readRSSI or didDiscover.
     private RSSI rssi;
     /// Transmit power data where available (only provided by Android devices)
@@ -101,6 +102,7 @@ public class BLEDevice {
         this.state = device.state;
         this.operatingSystem = device.operatingSystem;
         this.payloadData = device.payloadData;
+        this.lastPayloadDataUpdate = device.lastPayloadDataUpdate;
         this.rssi = device.rssi;
         this.txPower = device.txPower;
         this.receiveOnly = device.receiveOnly;
@@ -194,8 +196,16 @@ public class BLEDevice {
 
     public void payloadData(PayloadData payloadData) {
         this.payloadData = payloadData;
-        lastUpdatedAt = new Date();
+        lastPayloadDataUpdate = new Date();
+        lastUpdatedAt = lastPayloadDataUpdate;
         delegate.device(this, BLEDeviceAttribute.payloadData);
+    }
+
+    public TimeInterval timeIntervalSinceLastPayloadDataUpdate() {
+        if (lastPayloadDataUpdate == null) {
+            return TimeInterval.never;
+        }
+        return new TimeInterval((new Date().getTime() - lastPayloadDataUpdate.getTime()) / 1000);
     }
 
     public RSSI rssi() {

--- a/herald/src/main/java/com/vmware/herald/sensor/ble/BLESensorConfiguration.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/ble/BLESensorConfiguration.java
@@ -30,6 +30,8 @@ public class BLESensorConfiguration {
     public final static int manufacturerIdForSensor = 65530;
     /// Advert refresh time interval
     public final static TimeInterval advertRefreshTimeInterval = TimeInterval.minutes(15);
+    /// Payload update at regular intervals
+    public final static TimeInterval payloadDataUpdateTimeInterval = TimeInterval.never;
 
 
     /// Signal characteristic action code for write payload, expect 1 byte action code followed by 2 byte little-endian Int16 integer value for payload data length, then payload data

--- a/herald/src/main/java/com/vmware/herald/sensor/data/StatisticsDidReadLog.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/data/StatisticsDidReadLog.java
@@ -1,0 +1,101 @@
+//  Copyright 2020 VMware, Inc.
+//  SPDX-License-Identifier: MIT
+//
+
+package com.vmware.herald.sensor.data;
+
+import android.content.Context;
+
+import com.vmware.herald.sensor.DefaultSensorDelegate;
+import com.vmware.herald.sensor.datatype.PayloadData;
+import com.vmware.herald.sensor.datatype.Proximity;
+import com.vmware.herald.sensor.datatype.Sample;
+import com.vmware.herald.sensor.datatype.SensorType;
+import com.vmware.herald.sensor.datatype.TargetIdentifier;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/// CSV log of didRead calls for post event analysis and visualisation
+public class StatisticsDidReadLog extends DefaultSensorDelegate {
+    private final TextFile textFile;
+    private final PayloadData payloadData;
+    private final Map<String, Date> payloadToTime = new ConcurrentHashMap<>();
+    private final Map<String, Sample> payloadToSample = new ConcurrentHashMap<>();
+
+    public StatisticsDidReadLog(final Context context, final String filename, final PayloadData payloadData) {
+        textFile = new TextFile(context, filename);
+        this.payloadData = payloadData;
+    }
+
+    private String csv(String value) {
+        return TextFile.csv(value);
+    }
+
+    private void add(String payload) {
+        final Date time = payloadToTime.get(payload);
+        final Sample sample = payloadToSample.get(payload);
+        if (time == null || sample == null) {
+            payloadToTime.put(payload, new Date());
+            payloadToSample.put(payload, new Sample());
+            return;
+        }
+        final Date now = new Date();
+        payloadToTime.put(payload, now);
+        sample.add((now.getTime() - time.getTime()) / 1000d);
+        write();
+    }
+
+    private void write() {
+        final StringBuilder content = new StringBuilder("payload,count,mean,sd,min,max\n");
+        final List<String> payloadList = new ArrayList<>();
+        for (String payload : payloadToSample.keySet()) {
+            if (payload.equals(payloadData.shortName())) {
+                continue;
+            }
+            payloadList.add(payload);
+        }
+        Collections.sort(payloadList);
+        for (String payload : payloadList) {
+            final Sample sample = payloadToSample.get(payload);
+            if (sample == null) {
+                continue;
+            }
+            if (sample.mean() == null || sample.standardDeviation() == null || sample.min() == null || sample.max() == null) {
+                continue;
+            }
+            content.append(csv(payload));
+            content.append(',');
+            content.append(sample.count());
+            content.append(',');
+            content.append(sample.mean());
+            content.append(',');
+            content.append(sample.standardDeviation());
+            content.append(',');
+            content.append(sample.min());
+            content.append(',');
+            content.append(sample.max());
+            content.append('\n');
+        }
+        textFile.overwrite(content.toString());
+    }
+
+
+    // MARK:- SensorDelegate
+
+    @Override
+    public void sensor(SensorType sensor, PayloadData didRead, TargetIdentifier fromTarget) {
+        add(didRead.shortName());
+    }
+
+    @Override
+    public void sensor(SensorType sensor, List<PayloadData> didShare, TargetIdentifier fromTarget) {
+        for (PayloadData payload : didShare) {
+            add(payload.shortName());
+        }
+    }
+}

--- a/herald/src/main/java/com/vmware/herald/sensor/data/TextFile.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/data/TextFile.java
@@ -8,8 +8,11 @@ import android.content.Context;
 import android.media.MediaScannerConnection;
 import android.os.Environment;
 
+import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileOutputStream;
+import java.io.FileInputStream;
+import java.io.InputStreamReader;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -33,6 +36,26 @@ public class TextFile {
                 MediaScannerConnection.scanFile(context, new String[]{file.getAbsolutePath()}, null, null);
             }
         }, 30, 30, TimeUnit.SECONDS);
+    }
+
+    /// Get contents of file
+    public synchronized String contentsOf() {
+        try {
+            final FileInputStream fileInputStream = new FileInputStream(file);
+            final BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(fileInputStream));
+            final StringBuilder stringBuilder = new StringBuilder();
+            String line;
+            while ((line = bufferedReader.readLine()) != null) {
+                stringBuilder.append(line);
+                stringBuilder.append("\n");
+            }
+            bufferedReader.close();
+            fileInputStream.close();
+            return stringBuilder.toString();
+        } catch (Throwable e) {
+            logger.fault("read failed (file={})", file, e);
+            return "";
+        }
     }
 
     /**

--- a/herald/src/main/java/com/vmware/herald/sensor/datatype/Data.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/datatype/Data.java
@@ -31,6 +31,10 @@ public class Data {
         }
     }
 
+    public Data(String base64EncodedString) {
+        this.value = Base64.decode(base64EncodedString);
+    }
+
     public String base64EncodedString() {
         return Base64.encode(value);
     }

--- a/herald/src/main/java/com/vmware/herald/sensor/datatype/Encounter.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/datatype/Encounter.java
@@ -1,3 +1,7 @@
+//  Copyright 2020 VMware, Inc.
+//  SPDX-License-Identifier: MIT
+//
+
 package com.vmware.herald.sensor.datatype;
 
 import java.text.SimpleDateFormat;

--- a/herald/src/main/java/com/vmware/herald/sensor/datatype/Encounter.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/datatype/Encounter.java
@@ -1,0 +1,48 @@
+package com.vmware.herald.sensor.datatype;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+/// Encounter record describing proximity with target at a moment in time
+public class Encounter {
+    private final static SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+    public Date timestamp = null;
+    public Proximity proximity = null;
+    public PayloadData payload = null;
+
+    public Encounter(Proximity didMeasure, PayloadData withPayload, Date timestamp) {
+        this.timestamp = timestamp;
+        this.proximity = didMeasure;
+        this.payload = withPayload;
+    }
+
+    public Encounter(String row) {
+        final String[] fields = row.split(",");
+        if (!(fields.length >= 4)) {
+            return;
+        }
+        try {
+            this.timestamp = dateFormatter.parse(fields[0]);
+        } catch (Throwable e) {
+        }
+        try {
+            final double proximityValue = Double.parseDouble(fields[1]);
+            final ProximityMeasurementUnit proximityUnit = ProximityMeasurementUnit.valueOf(fields[2]);
+            this.proximity = new Proximity(proximityUnit, proximityValue);
+        } catch (Throwable e) {
+        }
+        this.payload = new PayloadData(fields[3]);
+    }
+
+    public String csvString() {
+        final String f0 = dateFormatter.format(timestamp);
+        final String f1 = proximity.value.toString();
+        final String f2 = proximity.unit.name();
+        final String f3 = payload.base64EncodedString();
+        return f0 + "," + f1 + "," + f2 + "," + f3;
+    }
+
+    public boolean isValid() {
+        return timestamp != null && proximity != null && payload != null;
+    }
+}

--- a/herald/src/main/java/com/vmware/herald/sensor/datatype/PayloadData.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/datatype/PayloadData.java
@@ -13,6 +13,10 @@ public class PayloadData extends Data {
         super(value);
     }
 
+    public PayloadData(String base64EncodedString) {
+        super(base64EncodedString);
+    }
+
     public PayloadData() {
         this(new byte[0]);
     }


### PR DESCRIPTION
- Enables an app to specify payload update frequency, in addition to default HERALD payload reads
- This enables app developer to choose the balance between security (more frequent payload updates reduces continuity and battery life) and performance (less updates increases continuity and battery life)
- Set BLESensorConfiguration.payloadDataUpdateTimeInterval to define minimum update interval
- Set value to TimeInterval.never (default) to disable feature and adopt HERALD approach which minimises payload reads for maximum performance
- Tested on iPhone 6S, iPhone 6 Plus, Google Pixel 2, Samsung J6 (non-advertising), Samsung A20 (frequency address change)
- Test shows small (circa 3%) impact on continuity

Closes #12

Signed-off-by: c19x <support@c19x.org>