### PR TITLE
UUID update

### DIFF
--- a/herald/src/main/java/com/vmware/herald/sensor/ble/BLESensorConfiguration.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/ble/BLESensorConfiguration.java
@@ -12,18 +12,18 @@ import java.util.UUID;
 /// Defines BLE sensor configuration data, e.g. service and characteristic UUIDs
 public class BLESensorConfiguration {
     public final static SensorLoggerLevel logLevel = SensorLoggerLevel.debug;
-    /**
-     * Service UUID for beacon service. This is a fixed UUID to enable iOS devices to find each other even
-     * in background mode. Android devices will need to find Apple devices first using the manufacturer code
-     * then discover services to identify actual beacons.
-     */
-    public final static UUID serviceUUID = UUID.fromString("FFFFFFFF-EEEE-DDDD-0000-000000000000");
+    /// Service UUID for beacon service. This is a fixed UUID to enable iOS devices to find each other even
+    /// in background mode. Android devices will need to find Apple devices first using the manufacturer code
+    /// then discover services to identify actual beacons.
+    /// - Service and characteristic UUIDs are V4 UUIDs that have been randomly generated and tested
+    /// for uniqueness by conducting web searches to ensure it returns no results.
+    public final static UUID serviceUUID = UUID.fromString("428132af-4746-42d3-801e-4572d65bfd9b");
     /// Signaling characteristic for controlling connection between peripheral and central, e.g. keep each other from suspend state
-    public final static UUID androidSignalCharacteristicUUID = UUID.fromString("FFFFFFFF-EEEE-DDDD-0000-000000000001");
+    public final static UUID androidSignalCharacteristicUUID = UUID.fromString("f617b813-092e-437a-8324-e09a80821a11");
     /// Signaling characteristic for controlling connection between peripheral and central, e.g. keep each other from suspend state
-    public final static UUID iosSignalCharacteristicUUID = UUID.fromString("FFFFFFFF-EEEE-DDDD-0000-000000000002");
+    public final static UUID iosSignalCharacteristicUUID = UUID.fromString("0eb0d5f2-eae4-4a9a-8af3-a4adb02d4363");
     /// Primary payload characteristic (read) for distributing payload data from peripheral to central, e.g. identity data
-    public final static UUID payloadCharacteristicUUID = UUID.fromString("FFFFFFFF-EEEE-DDDD-0000-000000000003");
+    public final static UUID payloadCharacteristicUUID = UUID.fromString("3e98c0f8-8f05-4829-a121-43e38f8933e7");
     /// Expiry time for shared payloads, to ensure only recently seen payloads are shared
     public final static TimeInterval payloadSharingExpiryTimeInterval = new TimeInterval(5 * TimeInterval.minute.value);
     /// Manufacturer data is being used on Android to store pseudo device address

--- a/herald/src/main/java/com/vmware/herald/sensor/datatype/Data.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/datatype/Data.java
@@ -56,7 +56,7 @@ public class Data {
 
     /// Get subdata from offset to offset + length
     public Data subdata(int offset, int length) {
-        if (offset + length < value.length) {
+        if (offset + length <= value.length) {
             final byte[] offsetValue = new byte[length];
             System.arraycopy(value, offset, offsetValue, 0, length);
             return new Data(offsetValue);

--- a/herald/src/main/java/com/vmware/herald/sensor/datatype/PayloadData.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/datatype/PayloadData.java
@@ -4,8 +4,6 @@
 
 package com.vmware.herald.sensor.datatype;
 
-import android.util.Base64;
-
 /// Encrypted payload data received from target. This is likely to be an encrypted datagram of the target's actual permanent identifier.
 public class PayloadData extends Data {
 
@@ -26,11 +24,16 @@ public class PayloadData extends Data {
     }
 
     public String shortName() {
-        try {
-            return Base64.encodeToString(value, 3, value.length - 3, Base64.DEFAULT | Base64.NO_WRAP).substring(0, 6);
-        } catch (Throwable e) {
-            return Base64.encodeToString(value, 0, value.length, Base64.DEFAULT | Base64.NO_WRAP);
+        if (value.length == 0) {
+            return "";
         }
+        if (!(value.length > 3)) {
+            return Base64.encode(value);
+        }
+        final Data subdata = subdata(3, value.length - 3);
+        final byte[] suffix = (subdata == null || subdata.value == null ? new byte[0] : subdata.value);
+        final String base64EncodedString = Base64.encode(suffix);
+        return base64EncodedString.substring(0, Math.min(6, base64EncodedString.length()));
     }
 
     public String toString() {

--- a/herald/src/test/java/com/vmware/herald/sensor/datatype/PayloadDataTests.java
+++ b/herald/src/test/java/com/vmware/herald/sensor/datatype/PayloadDataTests.java
@@ -1,0 +1,15 @@
+package com.vmware.herald.sensor.datatype;
+
+import org.junit.Test;
+
+public class PayloadDataTests {
+
+    @Test
+    public void testShortName() throws Exception {
+        for (int i=0; i<600; i++) {
+            final PayloadData payloadData = new PayloadData((byte) 0, i);
+            System.err.println(i + " -> " + payloadData.shortName());
+        }
+    }
+
+}


### PR DESCRIPTION
UUID update - Validated
    
    - UUID updated to V4 UUID to match iOS
    - Tested on Pixel 2, iPhone 6S, and iPhone 6 Plus

Removed PayloadData data length assumption - Validated
    
    - PayloadData assumed data has 3 byte header and length > 6 bytes
    - PayloadData.shortName for data < 6 bytes crashes HERALD
    - Removed assumption to support data length >= 0 bytes
    - Validated on Pixel 2

Closes #15 