### PR TITLE
Switch from 128-bit to 16-bit service UUID - Validated

### DIFF
--- a/herald/src/main/java/com/vmware/herald/sensor/ble/BLESensorConfiguration.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/ble/BLESensorConfiguration.java
@@ -11,28 +11,30 @@ import java.util.UUID;
 
 /// Defines BLE sensor configuration data, e.g. service and characteristic UUIDs
 public class BLESensorConfiguration {
-    public final static SensorLoggerLevel logLevel = SensorLoggerLevel.debug;
+    // MARK:- BLE service and characteristic UUID, and manufacturer ID
+
     /// Service UUID for beacon service. This is a fixed UUID to enable iOS devices to find each other even
     /// in background mode. Android devices will need to find Apple devices first using the manufacturer code
     /// then discover services to identify actual beacons.
-    /// - Service and characteristic UUIDs are V4 UUIDs that have been randomly generated and tested
-    /// for uniqueness by conducting web searches to ensure it returns no results.
-    public final static UUID serviceUUID = UUID.fromString("428132af-4746-42d3-801e-4572d65bfd9b");
+    /// - Generic networking 16-bit UUID
+    /// - Use 16-bit UUID by inserting ID in base UUID "0000xxxx-0000-1000-8000-00805F9B34FB"
+    public final static UUID serviceUUID = UUID.fromString("00001201-0000-1000-8000-00805F9B34FB");
     /// Signaling characteristic for controlling connection between peripheral and central, e.g. keep each other from suspend state
+    /// - Characteristic UUID is randomly generated V4 UUIDs that has been tested for uniqueness by conducting web searches to ensure it returns no results.
     public final static UUID androidSignalCharacteristicUUID = UUID.fromString("f617b813-092e-437a-8324-e09a80821a11");
     /// Signaling characteristic for controlling connection between peripheral and central, e.g. keep each other from suspend state
+    /// - Characteristic UUID is randomly generated V4 UUIDs that has been tested for uniqueness by conducting web searches to ensure it returns no results.
     public final static UUID iosSignalCharacteristicUUID = UUID.fromString("0eb0d5f2-eae4-4a9a-8af3-a4adb02d4363");
     /// Primary payload characteristic (read) for distributing payload data from peripheral to central, e.g. identity data
+    /// - Characteristic UUID is randomly generated V4 UUIDs that has been tested for uniqueness by conducting web searches to ensure it returns no results.
     public final static UUID payloadCharacteristicUUID = UUID.fromString("3e98c0f8-8f05-4829-a121-43e38f8933e7");
-    /// Expiry time for shared payloads, to ensure only recently seen payloads are shared
-    public final static TimeInterval payloadSharingExpiryTimeInterval = new TimeInterval(5 * TimeInterval.minute.value);
     /// Manufacturer data is being used on Android to store pseudo device address
+    /// - Pending update to dedicated ID
     public final static int manufacturerIdForSensor = 65530;
-    /// Advert refresh time interval
-    public final static TimeInterval advertRefreshTimeInterval = TimeInterval.minutes(15);
-    /// Payload update at regular intervals
-    public final static TimeInterval payloadDataUpdateTimeInterval = TimeInterval.never;
+    /// BLE advert manufacturer ID for Apple, for scanning of background iOS devices
+    public final static int manufacturerIdForApple = 76;
 
+    // MARK:- BLE signal characteristic action codes
 
     /// Signal characteristic action code for write payload, expect 1 byte action code followed by 2 byte little-endian Int16 integer value for payload data length, then payload data
     public final static byte signalCharacteristicActionWritePayload = (byte) 1;
@@ -43,6 +45,14 @@ public class BLESensorConfiguration {
     /// Arbitrary immediate write
     public final static byte signalCharacteristicActionWriteImmediate = (byte) 4;
 
-    // BLE advert manufacturer ID for Apple, for scanning of background iOS devices
-    public final static int manufacturerIdForApple = 76;
+    // MARK:- App configurable BLE features
+
+    /// Expiry time for shared payloads, to ensure only recently seen payloads are shared
+    public static TimeInterval payloadSharingExpiryTimeInterval = new TimeInterval(5 * TimeInterval.minute.value);
+    /// Advert refresh time interval
+    public static TimeInterval advertRefreshTimeInterval = TimeInterval.minutes(15);
+    /// Payload update at regular intervals
+    public static TimeInterval payloadDataUpdateTimeInterval = TimeInterval.never;
+    /// Sensor log level
+    public static SensorLoggerLevel logLevel = SensorLoggerLevel.debug;
 }

--- a/herald/src/main/java/com/vmware/herald/sensor/ble/ConcreteBLETransmitter.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/ble/ConcreteBLETransmitter.java
@@ -324,7 +324,7 @@ public class ConcreteBLETransmitter implements BLETransmitter, BluetoothStateMan
         final PseudoDeviceAddress pseudoDeviceAddress = new PseudoDeviceAddress();
         final AdvertiseData data = new AdvertiseData.Builder()
                 .setIncludeDeviceName(false)
-                .setIncludeTxPowerLevel(false)
+                .setIncludeTxPowerLevel(true)
                 .addServiceUuid(new ParcelUuid(BLESensorConfiguration.serviceUUID))
                 .addManufacturerData(BLESensorConfiguration.manufacturerIdForSensor, pseudoDeviceAddress.data)
                 .build();


### PR DESCRIPTION
- Migrated to 16-bit service UUID to enable advertising of TxPower and PseudoDeviceAddress
- Separation of static and app configurable parameters in BLESensorConfiguration
- Tested on Pixel 2, iPhone 6S, iPhone 6 Plus

Closes #18 

Signed-off-by: c19x <support@c19x.org>