### PR TITLE
ImmediateSend UI + Logic

### DIFF
--- a/app/src/main/java/com/vmware/herald/app/MainActivity.java
+++ b/app/src/main/java/com/vmware/herald/app/MainActivity.java
@@ -33,6 +33,8 @@ import com.vmware.herald.sensor.datatype.SensorType;
 import com.vmware.herald.sensor.datatype.TargetIdentifier;
 import com.vmware.herald.sensor.datatype.TimeInterval;
 
+import org.w3c.dom.Text;
+
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -143,6 +145,7 @@ public class MainActivity extends AppCompatActivity implements SensorDelegate, A
                 return t0.payloadData().shortName().compareTo(t1.payloadData().shortName());
             }
         });
+        ((TextView) findViewById(R.id.detection)).setText("DETECTION (" + targetListAdapter.getCount() + ")");
         targetListAdapter.clear();
         targetListAdapter.addAll(targetList);
     }

--- a/app/src/main/java/com/vmware/herald/app/MainActivity.java
+++ b/app/src/main/java/com/vmware/herald/app/MainActivity.java
@@ -296,10 +296,11 @@ public class MainActivity extends AppCompatActivity implements SensorDelegate, A
     @Override
     public void sensor(SensorType sensor, ImmediateSendData didReceive, TargetIdentifier fromTarget) {
         this.didReceive++;
-        final PayloadData didRead = targetIdentifiers.get(fromTarget);
+        final PayloadData didRead = new PayloadData(didReceive.data.value);
         if (didRead != null) {
             final Target target = payloads.get(didRead);
             if (target != null) {
+                targetIdentifiers.put(fromTarget, didRead);
                 target.targetIdentifier(fromTarget);
                 target.received(didReceive);
             }
@@ -337,7 +338,12 @@ public class MainActivity extends AppCompatActivity implements SensorDelegate, A
         final Target target = targetListAdapter.getItem(i);
         final SensorArray sensor = (SensorArray) AppDelegate.getAppDelegate().sensor();
         final PayloadData payloadData = sensor.payloadData();
-        final boolean result = sensor.immediateSend(payloadData, target.targetIdentifier());
-        Log.d(tag, "immediateSend (to=" + target.payloadData().shortName() + ",result=" + result + ")");
+        new Thread(new Runnable() {
+            @Override
+            public void run() {
+                final boolean result = sensor.immediateSend(payloadData, target.targetIdentifier());
+                Log.d(tag, "immediateSend (to=" + target.payloadData().shortName() + ",result=" + result + ")");
+            }
+        }).start();
     }
 }

--- a/app/src/main/java/com/vmware/herald/app/Target.java
+++ b/app/src/main/java/com/vmware/herald/app/Target.java
@@ -1,0 +1,92 @@
+//  Copyright 2020 VMware, Inc.
+//  SPDX-License-Identifier: MIT
+//
+
+package com.vmware.herald.app;
+
+import com.vmware.herald.sensor.datatype.Data;
+import com.vmware.herald.sensor.datatype.ImmediateSendData;
+import com.vmware.herald.sensor.datatype.PayloadData;
+import com.vmware.herald.sensor.datatype.Proximity;
+import com.vmware.herald.sensor.datatype.TargetIdentifier;
+
+import java.util.Date;
+
+public class Target {
+    private TargetIdentifier targetIdentifier;
+    private PayloadData payloadData;
+    private Date lastUpdatedAt;
+    private Proximity proximity;
+    private ImmediateSendData received;
+    private Date didRead, didMeasure, didShare, didReceive;
+
+    public Target(TargetIdentifier targetIdentifier, PayloadData payloadData) {
+        this.targetIdentifier = targetIdentifier;
+        this.payloadData = payloadData;
+        lastUpdatedAt = new Date();
+        didRead = lastUpdatedAt;
+    }
+
+    public TargetIdentifier targetIdentifier() {
+        return targetIdentifier;
+    }
+
+    public void targetIdentifier(TargetIdentifier targetIdentifier) {
+        lastUpdatedAt = new Date();
+        this.targetIdentifier = targetIdentifier;
+    }
+
+    public PayloadData payloadData() {
+        return payloadData;
+    }
+
+    public Date lastUpdatedAt() {
+        return lastUpdatedAt;
+    }
+
+    public Proximity proximity() {
+        return proximity;
+    }
+
+    public void proximity(Proximity proximity) {
+        lastUpdatedAt = new Date();
+        didMeasure = lastUpdatedAt;
+        this.proximity = proximity;
+    }
+
+    public ImmediateSendData received() {
+        return received;
+    }
+
+    public void received(ImmediateSendData received) {
+        lastUpdatedAt = new Date();
+        didReceive = lastUpdatedAt;
+        this.received = received;
+    }
+
+    public Date didReceive() {
+        return didReceive;
+    }
+
+    public Date didRead() {
+        return didRead;
+    }
+
+    public void didRead(Date date) {
+        didRead = date;
+        lastUpdatedAt = didRead;
+    }
+
+    public Date didMeasure() {
+        return didMeasure;
+    }
+
+    public Date didShare() {
+        return didShare;
+    }
+
+    public void didShare(Date date) {
+        didShare = date;
+        lastUpdatedAt = didShare;
+    }
+}

--- a/app/src/main/java/com/vmware/herald/app/TargetListAdapter.java
+++ b/app/src/main/java/com/vmware/herald/app/TargetListAdapter.java
@@ -1,0 +1,45 @@
+//  Copyright 2020 VMware, Inc.
+//  SPDX-License-Identifier: MIT
+//
+
+package com.vmware.herald.app;
+
+import android.content.Context;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ArrayAdapter;
+import android.widget.ListAdapter;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.text.SimpleDateFormat;
+import java.util.List;
+
+/// Target list adapter for presenting list of targets on UI
+public class TargetListAdapter extends ArrayAdapter<Target> {
+    private final static SimpleDateFormat dateFormatter = new SimpleDateFormat("YYYY-MM-dd HH:mm:ss");
+    private final static SimpleDateFormat dateFormatterTime = new SimpleDateFormat("HH:mm:ss");
+
+    public TargetListAdapter(@NonNull Context context, List<Target> targets) {
+        super(context, R.layout.listview_targets_row, targets);
+    }
+
+    @NonNull
+    @Override
+    public View getView(int position, @Nullable View convertView, @NonNull ViewGroup parent) {
+        final Target target = getItem(position);
+        if (convertView == null) {
+            convertView = LayoutInflater.from(getContext()).inflate(R.layout.listview_targets_row, parent, false);
+        }
+        final TextView textLabel = (TextView) convertView.findViewById(R.id.targetTextLabel);
+        final TextView detailedTextLabel = (TextView) convertView.findViewById(R.id.targetDetailedTextLabel);
+        final String method = "read" + (target.didShare() == null ? "" : ",share");
+        final String didReceive = (target.didReceive() == null ? "" : " (receive " + dateFormatterTime.format(target.didReceive()) + ")");
+        textLabel.setText(target.payloadData().shortName() + " [" + method + "]");
+        detailedTextLabel.setText(dateFormatter.format(target.lastUpdatedAt()) + didReceive);
+        return convertView;
+    }
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -17,6 +17,7 @@
         android:text="DEVICE"
         android:padding="10dp"
         android:textSize="20sp"
+        android:textStyle="bold"
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintRight_toRightOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
@@ -25,9 +26,11 @@
         android:id="@+id/payload"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:paddingBottom="10dp"
+        android:paddingHorizontal="10dp"
         android:text="PAYLOAD : "
-        android:padding="10dp"
         android:textSize="20sp"
+        android:textStyle="bold"
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintRight_toRightOf="parent"
         app:layout_constraintTop_toBottomOf="@id/device" />
@@ -131,9 +134,9 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:textSize="14sp"
-                android:text="Visit"/>
+                android:text="Receive"/>
             <TextView
-                android:id="@+id/didVisitCount"
+                android:id="@+id/didReceiveCount"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:textSize="17sp"
@@ -385,19 +388,20 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="DETECTION (0)"
-        android:textSize="20sp"
-        android:padding="10dp"
+        android:textSize="18sp"
+        android:textStyle="bold"
+        android:layout_marginTop="10dp"
+        android:paddingVertical="5dp"
+        android:paddingHorizontal="10dp"
+        android:background="@color/systemGray6"
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintRight_toRightOf="parent"
         app:layout_constraintTop_toBottomOf="@id/socialMixingScoreUnit" />
 
-    <TextView
-        android:id="@+id/payloads"
+    <ListView
+        android:id="@+id/targets"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:textSize="16sp"
-        android:padding="10dp"
-        android:scrollbars="vertical"
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintRight_toRightOf="parent"
         app:layout_constraintTop_toBottomOf="@id/detection" />

--- a/app/src/main/res/layout/listview_targets_row.xml
+++ b/app/src/main/res/layout/listview_targets_row.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- Copyright 2020 VMware, Inc. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:paddingVertical="8dp"
+    android:paddingHorizontal="10dp">
+    <TextView
+        android:id="@+id/targetTextLabel"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textSize="16sp"
+        android:text="TextLabel"/>
+
+    <TextView
+        android:id="@+id/targetDetailedTextLabel"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textSize="12sp"
+        android:text="DetailedTextLabel"/>
+</LinearLayout>

--- a/herald/src/main/java/com/vmware/herald/sensor/ble/BLESensorConfiguration.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/ble/BLESensorConfiguration.java
@@ -11,7 +11,8 @@ import java.util.UUID;
 
 /// Defines BLE sensor configuration data, e.g. service and characteristic UUIDs
 public class BLESensorConfiguration {
-    public final static SensorLoggerLevel logLevel = SensorLoggerLevel.debug;
+    // MARK:- BLE service and characteristic UUID, and manufacturer ID
+
     /// Service UUID for beacon service. This is a fixed UUID to enable iOS devices to find each other even
     /// in background mode. Android devices will need to find Apple devices first using the manufacturer code
     /// then discover services to identify actual beacons.
@@ -19,20 +20,21 @@ public class BLESensorConfiguration {
     /// for uniqueness by conducting web searches to ensure it returns no results.
     public final static UUID serviceUUID = UUID.fromString("428132af-4746-42d3-801e-4572d65bfd9b");
     /// Signaling characteristic for controlling connection between peripheral and central, e.g. keep each other from suspend state
+    /// - Characteristic UUID is randomly generated V4 UUIDs that has been tested for uniqueness by conducting web searches to ensure it returns no results.
     public final static UUID androidSignalCharacteristicUUID = UUID.fromString("f617b813-092e-437a-8324-e09a80821a11");
     /// Signaling characteristic for controlling connection between peripheral and central, e.g. keep each other from suspend state
+    /// - Characteristic UUID is randomly generated V4 UUIDs that has been tested for uniqueness by conducting web searches to ensure it returns no results.
     public final static UUID iosSignalCharacteristicUUID = UUID.fromString("0eb0d5f2-eae4-4a9a-8af3-a4adb02d4363");
     /// Primary payload characteristic (read) for distributing payload data from peripheral to central, e.g. identity data
+    /// - Characteristic UUID is randomly generated V4 UUIDs that has been tested for uniqueness by conducting web searches to ensure it returns no results.
     public final static UUID payloadCharacteristicUUID = UUID.fromString("3e98c0f8-8f05-4829-a121-43e38f8933e7");
-    /// Expiry time for shared payloads, to ensure only recently seen payloads are shared
-    public final static TimeInterval payloadSharingExpiryTimeInterval = new TimeInterval(5 * TimeInterval.minute.value);
     /// Manufacturer data is being used on Android to store pseudo device address
+    /// - Pending update to dedicated ID
     public final static int manufacturerIdForSensor = 65530;
-    /// Advert refresh time interval
-    public final static TimeInterval advertRefreshTimeInterval = TimeInterval.minutes(15);
-    /// Payload update at regular intervals
-    public final static TimeInterval payloadDataUpdateTimeInterval = TimeInterval.never;
+    /// BLE advert manufacturer ID for Apple, for scanning of background iOS devices
+    public final static int manufacturerIdForApple = 76;
 
+    // MARK:- BLE signal characteristic action codes
 
     /// Signal characteristic action code for write payload, expect 1 byte action code followed by 2 byte little-endian Int16 integer value for payload data length, then payload data
     public final static byte signalCharacteristicActionWritePayload = (byte) 1;
@@ -43,6 +45,21 @@ public class BLESensorConfiguration {
     /// Arbitrary immediate write
     public final static byte signalCharacteristicActionWriteImmediate = (byte) 4;
 
-    // BLE advert manufacturer ID for Apple, for scanning of background iOS devices
-    public final static int manufacturerIdForApple = 76;
+    // MARK:- App configurable BLE features
+
+    /// Log level for BLESensor
+    public static SensorLoggerLevel logLevel = SensorLoggerLevel.debug;
+
+    /// Payload update at regular intervals, in addition to default HERALD communication process.
+    /// - Use this to enable regular payload reads according to app payload lifespan.
+    /// - Set to .never to disable this function.
+    /// - Payload updates are reported to SensorDelegate as didRead.
+    /// - Setting take immediate effect, no need to restart BLESensor, can also be applied while BLESensor is active.
+    public static TimeInterval payloadDataUpdateTimeInterval = TimeInterval.never;
+
+    /// Expiry time for shared payloads, to ensure only recently seen payloads are shared
+    public static TimeInterval payloadSharingExpiryTimeInterval = new TimeInterval(5 * TimeInterval.minute.value);
+
+    /// Advert refresh time interval
+    public static TimeInterval advertRefreshTimeInterval = TimeInterval.minutes(15);
 }


### PR DESCRIPTION
- ImmediateSend UI update to enable display of didReceive
- Trigger ImmediateSend to target device by tapping on target device on UI
- Target device shows "(receive [timestamp])" on didReceive, and increment of "Receive" count
- ImmediateSend logic update for Android->iOS immediate send to send once only (previous implementation sends repeatedly)
- ImmediateSend update to use existing signal characteristic write functions to enable immediate send of > 20 bytes of data, with fragmentation as required, and also write with response for Android->iOS compatibility