### PR TITLE
Ignore logic update + New retry limit

### DIFF
--- a/herald/src/main/java/com/vmware/herald/sensor/ble/BLEDevice.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/ble/BLEDevice.java
@@ -173,9 +173,13 @@ public class BLEDevice {
             }
             ignoreUntil = new Date(lastUpdatedAt.getTime() + ignoreForDuration.millis());
         } else {
-            ignoreForDuration = null;
             ignoreUntil = null;
         }
+        // Reset ignore for duration if operating system has been confirmed
+        if (operatingSystem == BLEDeviceOperatingSystem.ios || operatingSystem == BLEDeviceOperatingSystem.android) {
+            ignoreForDuration = null;
+        }
+        // Set operating system
         if (this.operatingSystem != operatingSystem) {
             this.operatingSystem = operatingSystem;
             delegate.device(this, BLEDeviceAttribute.operatingSystem);
@@ -310,6 +314,13 @@ public class BLEDevice {
             return TimeInterval.never;
         }
         return new TimeInterval((new Date().getTime() - lastWritePayloadSharingAt.getTime()) / 1000);
+    }
+
+    public TimeInterval timeIntervalUntilIgnoreExpires() {
+        if (ignoreUntil == null) {
+            return TimeInterval.zero;
+        }
+        return new TimeInterval((ignoreUntil.getTime() - new Date().getTime()) / 1000);
     }
 
     @Override

--- a/herald/src/main/java/com/vmware/herald/sensor/ble/BLESensorConfiguration.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/ble/BLESensorConfiguration.java
@@ -62,4 +62,12 @@ public class BLESensorConfiguration {
 
     /// Advert refresh time interval
     public static TimeInterval advertRefreshTimeInterval = TimeInterval.minutes(15);
+
+    /// Ignore device permanently after a number of failed connection and service discovery attempts. This
+    /// is particularly useful for ignoring Apple devices not advertising HERALD services, i.e. Apple TV,
+    /// and Mac computers.
+    /// - Set to null to disable this feature, to ensure all devices are found
+    /// - Set to N to ignore device permanently after N failed attempts to connect or find HERALD service
+    /// - Note the ignore logic increases time between retries on each failed attempt to up to 3 mins per retry
+    public static Integer ignoreDevicePermanentlyAfterRetries = null;
 }

--- a/herald/src/main/java/com/vmware/herald/sensor/ble/ConcreteBLEReceiver.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/ble/ConcreteBLEReceiver.java
@@ -670,7 +670,7 @@ public class ConcreteBLEReceiver extends BluetoothGattCallback implements BLERec
     private NextTask nextTaskForDevice(final BLEDevice device) {
         // No task for devices marked as .ignore
         if (device.ignore()) {
-            logger.debug("nextTaskForDevice, ignore (device={},ignoreExpiresIn={}s)", device, device.timeIntervalUntilIgnoreExpires());
+            logger.debug("nextTaskForDevice, ignore (device={},ignoreExpiresIn={},ignoreRequestCount={})", device, device.timeIntervalUntilIgnoreExpires(), device.ignoreRequestCount());
             return NextTask.nothing;
         }
         // If marked as ignore but ignore has expired, change to unknown

--- a/herald/src/main/java/com/vmware/herald/sensor/ble/ConcreteBLEReceiver.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/ble/ConcreteBLEReceiver.java
@@ -670,6 +670,7 @@ public class ConcreteBLEReceiver extends BluetoothGattCallback implements BLERec
     private NextTask nextTaskForDevice(final BLEDevice device) {
         // No task for devices marked as .ignore
         if (device.ignore()) {
+            logger.debug("nextTaskForDevice, ignore (device={},ignoreExpiresIn={}s)", device, device.timeIntervalUntilIgnoreExpires());
             return NextTask.nothing;
         }
         // If marked as ignore but ignore has expired, change to unknown


### PR DESCRIPTION
BLE devices that do not accept connections or does not advertise HERALD services should be ignored, but BLE is unreliable, thus one failed connection or discovery attempt doesn't mean the device should be ignored. Furthermore, a BLE device not advertising HERALD service (e.g. APP closed by mistake), may do so later (e.g. APP open), thus retry is necessary.

- Improved ignore logic to retry at increasing time (starts with retry after 1mins, increasing time by 20% on each retry, up to 3mins).
- New app configurable parameter to ignore device permanently after N connection or service discovery failures. This is disabled by default.

This is an efficiency improvement, and also initial fix for the Apple TV problem that may or may not be caused by HERALD.

#27 (partial only, pending further investigation)
