### PR TITLE
Removal of ACCESS_BACKGROUND_LOCATION permission - Validated

### DIFF
--- a/app/src/main/java/com/vmware/herald/app/MainActivity.java
+++ b/app/src/main/java/com/vmware/herald/app/MainActivity.java
@@ -97,9 +97,6 @@ public class MainActivity extends AppCompatActivity implements SensorDelegate, A
         requiredPermissions.add(Manifest.permission.BLUETOOTH_ADMIN);
         requiredPermissions.add(Manifest.permission.ACCESS_COARSE_LOCATION);
         requiredPermissions.add(Manifest.permission.ACCESS_FINE_LOCATION);
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-            requiredPermissions.add(Manifest.permission.ACCESS_BACKGROUND_LOCATION);
-        }
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
             requiredPermissions.add(Manifest.permission.FOREGROUND_SERVICE);
         }

--- a/herald/src/main/AndroidManifest.xml
+++ b/herald/src/main/AndroidManifest.xml
@@ -9,7 +9,6 @@
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
-    <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
 


### PR DESCRIPTION
- Extensive tests over 48hr+ shows removal of permission has no impact
- Tested on Pixel 2 running Android 10

Closes #41 

Signed-off-by: c19x <support@c19x.org>