### PR TITLE
Proximity includes Calibration data - Validated

### DIFF
--- a/herald/src/main/java/com/vmware/herald/sensor/ble/BLEDevice.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/ble/BLEDevice.java
@@ -8,6 +8,8 @@ import android.bluetooth.BluetoothDevice;
 import android.bluetooth.BluetoothGattCharacteristic;
 import android.bluetooth.le.ScanRecord;
 
+import com.vmware.herald.sensor.datatype.Calibration;
+import com.vmware.herald.sensor.datatype.CalibrationMeasurementUnit;
 import com.vmware.herald.sensor.datatype.Data;
 import com.vmware.herald.sensor.datatype.PayloadData;
 import com.vmware.herald.sensor.datatype.PseudoDeviceAddress;
@@ -253,6 +255,13 @@ public class BLEDevice {
         this.txPower = txPower;
         lastUpdatedAt = new Date();
         delegate.device(this, BLEDeviceAttribute.txPower);
+    }
+
+    public Calibration calibration() {
+        if (txPower == null) {
+            return null;
+        }
+        return new Calibration(CalibrationMeasurementUnit.BLETransmitPower, new Double(txPower.value));
     }
 
     public boolean receiveOnly() {

--- a/herald/src/main/java/com/vmware/herald/sensor/ble/BLESensorConfiguration.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/ble/BLESensorConfiguration.java
@@ -18,6 +18,7 @@ public class BLESensorConfiguration {
     /// then discover services to identify actual beacons.
     /// - Service and characteristic UUIDs are V4 UUIDs that have been randomly generated and tested
     /// for uniqueness by conducting web searches to ensure it returns no results.
+    /// - Switch to 16-bit UUID by setting the value xxxx in base UUID 0000xxxx-0000-1000-8000-00805F9B34FB
     public final static UUID serviceUUID = UUID.fromString("428132af-4746-42d3-801e-4572d65bfd9b");
     /// Signaling characteristic for controlling connection between peripheral and central, e.g. keep each other from suspend state
     /// - Characteristic UUID is randomly generated V4 UUIDs that has been tested for uniqueness by conducting web searches to ensure it returns no results.

--- a/herald/src/main/java/com/vmware/herald/sensor/ble/ConcreteBLEReceiver.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/ble/ConcreteBLEReceiver.java
@@ -17,6 +17,7 @@ import android.bluetooth.le.ScanRecord;
 import android.bluetooth.le.ScanResult;
 import android.bluetooth.le.ScanSettings;
 import android.content.Context;
+import android.os.Build;
 import android.os.ParcelUuid;
 
 import com.vmware.herald.sensor.data.ConcreteSensorLogger;
@@ -379,10 +380,18 @@ public class ConcreteBLEReceiver extends BluetoothGattCallback implements BLERec
         final List<BLEDevice> devices = new ArrayList<>();
         for (ScanResult scanResult : scanResultList) {
             final BLEDevice device = database.device(scanResult);
-            device.scanRecord(scanResult.getScanRecord());
             if (deviceSet.add(device)) {
                 logger.debug("didDiscover (device={})", device);
                 devices.add(device);
+            }
+            // Set scan record
+            device.scanRecord(scanResult.getScanRecord());
+            // Set TX power level
+            if (device.scanRecord() != null) {
+                int txPowerLevel = device.scanRecord().getTxPowerLevel();
+                if (txPowerLevel != Integer.MIN_VALUE) {
+                    device.txPower(new BLE_TxPower(txPowerLevel));
+                }
             }
             // Identify operating system from scan record where possible
             // - Sensor service found + Manufacturer is Apple -> iOS (Foreground)

--- a/herald/src/main/java/com/vmware/herald/sensor/ble/ConcreteBLESensor.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/ble/ConcreteBLESensor.java
@@ -98,7 +98,7 @@ public class ConcreteBLESensor implements BLESensor, BLEDatabaseDelegate, Blueto
                 if (rssi == null) {
                     return;
                 }
-                final Proximity proximity = new Proximity(ProximityMeasurementUnit.RSSI, (double) rssi.value);
+                final Proximity proximity = new Proximity(ProximityMeasurementUnit.RSSI, (double) rssi.value, device.calibration());
                 logger.debug("didMeasure (device={},payloadData={},proximity={})", device, device.payloadData(), proximity.description());
                 operationQueue.execute(new Runnable() {
                     @Override

--- a/herald/src/main/java/com/vmware/herald/sensor/datatype/Calibration.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/datatype/Calibration.java
@@ -1,0 +1,31 @@
+//  Copyright 2020 VMware, Inc.
+//  SPDX-License-Identifier: MIT
+//
+
+package com.vmware.herald.sensor.datatype;
+
+import androidx.annotation.NonNull;
+
+/// Calibration data for interpreting proximity value between sensor and target, e.g. Transmit power for BLE.
+public class Calibration {
+    /// Unit of measurement, e.g. transmit power
+    public final CalibrationMeasurementUnit unit;
+    /// Measured value, e.g. transmit power in BLE advert
+    public final Double value;
+
+    public Calibration(CalibrationMeasurementUnit unit, Double value) {
+        this.unit = unit;
+        this.value = value;
+    }
+
+    /// Get plain text description of calibration data
+    public String description() {
+        return unit + ":" + value;
+    }
+
+    @NonNull
+    @Override
+    public String toString() {
+        return description();
+    }
+}

--- a/herald/src/main/java/com/vmware/herald/sensor/datatype/CalibrationMeasurementUnit.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/datatype/CalibrationMeasurementUnit.java
@@ -1,0 +1,11 @@
+//  Copyright 2020 VMware, Inc.
+//  SPDX-License-Identifier: MIT
+//
+
+package com.vmware.herald.sensor.datatype;
+
+/// Measurement unit for calibrating the proximity transmission data values, e.g. BLE transmit power
+public enum CalibrationMeasurementUnit {
+    /// Bluetooth transmit power for describing expected RSSI at 1 metre for interpretation of measured RSSI value.
+    BLETransmitPower
+}

--- a/herald/src/main/java/com/vmware/herald/sensor/datatype/Encounter.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/datatype/Encounter.java
@@ -26,28 +26,37 @@ public class Encounter {
 
     public Encounter(String row) {
         final String[] fields = row.split(",");
-        if (!(fields.length >= 4)) {
+        if (!(fields.length >= 6)) {
             return;
         }
         try {
             this.timestamp = dateFormatter.parse(fields[0]);
         } catch (Throwable e) {
         }
+        Calibration calibration = null;
+        try {
+            final double calibrationValue = Double.parseDouble(fields[3]);
+            final CalibrationMeasurementUnit calibrationUnit = CalibrationMeasurementUnit.valueOf(fields[4]);
+            calibration = new Calibration(calibrationUnit, calibrationValue);
+        } catch (Throwable e) {
+        }
         try {
             final double proximityValue = Double.parseDouble(fields[1]);
             final ProximityMeasurementUnit proximityUnit = ProximityMeasurementUnit.valueOf(fields[2]);
-            this.proximity = new Proximity(proximityUnit, proximityValue);
+            this.proximity = new Proximity(proximityUnit, proximityValue, calibration);
         } catch (Throwable e) {
         }
-        this.payload = new PayloadData(fields[3]);
+        this.payload = new PayloadData(fields[5]);
     }
 
     public String csvString() {
         final String f0 = dateFormatter.format(timestamp);
         final String f1 = proximity.value.toString();
         final String f2 = proximity.unit.name();
-        final String f3 = payload.base64EncodedString();
-        return f0 + "," + f1 + "," + f2 + "," + f3;
+        final String f3 = (proximity.calibration == null || proximity.calibration.value == null ? "" : proximity.calibration.value.toString());
+        final String f4 = (proximity.calibration == null || proximity.calibration.unit == null ? "" : proximity.calibration.unit.name());
+        final String f5 = payload.base64EncodedString();
+        return f0 + "," + f1 + "," + f2 + "," + f3 + "," + f4 + "," + f5;
     }
 
     public boolean isValid() {

--- a/herald/src/main/java/com/vmware/herald/sensor/datatype/Proximity.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/datatype/Proximity.java
@@ -12,15 +12,25 @@ public class Proximity {
     public final ProximityMeasurementUnit unit;
     /// Measured value, e.g. raw RSSI value.
     public final Double value;
+    /// Calibration data (optional), e.g. transmit power
+    public final Calibration calibration;
 
     public Proximity(ProximityMeasurementUnit unit, Double value) {
+        this(unit, value, null);
+    }
+
+    public Proximity(ProximityMeasurementUnit unit, Double value, Calibration calibration) {
         this.unit = unit;
         this.value = value;
+        this.calibration = calibration;
     }
 
     /// Get plain text description of proximity data
     public String description() {
-        return unit + ":" + value;
+        if (calibration == null) {
+            return unit + ":" + value;
+        }
+        return unit + ":" + value + "[" + calibration.description() + "]";
     }
 
     @NonNull


### PR DESCRIPTION
- Proximity includes Calibration data where available
- BLE RSSI measurements include BLE Transmit Power as Calibration data if available in advert
- BLE uses ScanRecord.getTxPowerLevel() which has been available since API 21 (Android 5.0)
- BLE does not use ScanResult.getTxPower() which requires API 26 (Android 8.0) and is typically not set
- Tested on Pixel 2 (Android 10), Samsung J20 (Android 10), iPhone X (iOS 14.2)

NOTE: TX power can only be included in Android advert by switching to 16-bit service UUID.

Closes #42 

Signed-off-by: c19x <support@c19x.org>