### PR TITLE
Standard bluetooth services

### DIFF
--- a/app/src/main/java/com/vmware/herald/app/TargetListAdapter.java
+++ b/app/src/main/java/com/vmware/herald/app/TargetListAdapter.java
@@ -38,12 +38,21 @@ public class TargetListAdapter extends ArrayAdapter<Target> {
         }
         final TextView textLabel = (TextView) convertView.findViewById(R.id.targetTextLabel);
         final TextView detailedTextLabel = (TextView) convertView.findViewById(R.id.targetDetailedTextLabel);
-        final String method = "read" + (target.didShare() == null ? "" : ",share");
-        final String didReadTimeInterval = (target.didReadTimeInterval().count() == 0 ? null : decimalFormat.format(target.didReadTimeInterval().mean()) + "s");
-        final String didMeasureTimeInterval = (target.didMeasureTimeInterval().count() == 0 ? null : decimalFormat.format(target.didMeasureTimeInterval().mean()) + "s");
-        final String timeIntervals = (didReadTimeInterval == null || didMeasureTimeInterval == null ? "" : " (R:" + didReadTimeInterval + "," + "M:" + didMeasureTimeInterval + ")");
+        final StringBuilder attributes = new StringBuilder();
+        attributes.append("Read");
+        if (target.didReadTimeInterval().count() != 0) {
+            attributes.append("=");
+            attributes.append(decimalFormat.format(target.didReadTimeInterval().mean()) + "s");
+        }
+        if (target.didMeasureTimeInterval().count() != 0) {
+            attributes.append(",Measure=");
+            attributes.append(decimalFormat.format(target.didMeasureTimeInterval().mean()) + "s");
+        }
+        if (target.didShare() != null) {
+            attributes.append(",Share");
+        }
         final String didReceive = (target.didReceive() == null ? "" : " (receive " + dateFormatterTime.format(target.didReceive()) + ")");
-        textLabel.setText(target.payloadData().shortName() + " [" + method + "]" + timeIntervals);
+        textLabel.setText(target.payloadData().shortName() + " [" + attributes.toString() + "]");
         detailedTextLabel.setText(dateFormatter.format(target.lastUpdatedAt()) + didReceive);
         return convertView;
     }

--- a/herald/src/main/java/com/vmware/herald/sensor/ble/BLEDevice.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/ble/BLEDevice.java
@@ -95,7 +95,14 @@ public class BLEDevice {
     }
 
     public String description() {
-        return "BLEDevice[id=" + identifier + ",os=" + operatingSystem + ",payload=" + payloadData() + ",address=" + pseudoDeviceAddress() + "]";
+        return "BLEDevice[" +
+                "id=" + identifier +
+                ",os=" + operatingSystem +
+                ",payload=" + payloadData() +
+                (pseudoDeviceAddress() != null ? ",address=" + pseudoDeviceAddress() : "") +
+                (deviceName() != null ? ",name=" + deviceName() : "") +
+                (model() != null ? ",model=" + model() : "") +
+                "]";
     }
 
     public BLEDevice(TargetIdentifier identifier, BLEDeviceDelegate delegate) {
@@ -125,6 +132,10 @@ public class BLEDevice {
         this.scanRecord = device.scanRecord;
         this.signalCharacteristic = device.signalCharacteristic;
         this.payloadCharacteristic = device.payloadCharacteristic;
+        this.modelCharacteristic = device.modelCharacteristic;
+        this.deviceNameCharacteristic = device.deviceNameCharacteristic;
+        this.model = device.model;
+        this.deviceName = device.deviceName;
         this.signalCharacteristicWriteValue = device.signalCharacteristicWriteValue;
         this.signalCharacteristicWriteQueue = device.signalCharacteristicWriteQueue;
         this.lastDiscoveredAt = device.lastDiscoveredAt;
@@ -281,6 +292,8 @@ public class BLEDevice {
     public void invalidateCharacteristics() {
         signalCharacteristic = null;
         payloadCharacteristic = null;
+        modelCharacteristic = null;
+        deviceNameCharacteristic = null;
     }
 
     public BluetoothGattCharacteristic signalCharacteristic() {
@@ -307,6 +320,7 @@ public class BLEDevice {
 
     public void modelCharacteristic(BluetoothGattCharacteristic modelCharacteristic) {
         this.modelCharacteristic = modelCharacteristic;
+        lastUpdatedAt = new Date();
     }
 
     public boolean supportsDeviceNameCharacteristic() { return null != deviceNameCharacteristic; }
@@ -315,18 +329,21 @@ public class BLEDevice {
 
     public void deviceNameCharacteristic(BluetoothGattCharacteristic deviceNameCharacteristic) {
         this.deviceNameCharacteristic = deviceNameCharacteristic;
+        lastUpdatedAt = new Date();
     }
 
     public String deviceName() { return deviceName; }
 
     public void deviceName(String deviceName) {
         this.deviceName = deviceName;
+        lastUpdatedAt = new Date();
     }
 
     public String model() { return model; }
 
     public void model(String model) {
         this.model = model;
+        lastUpdatedAt = new Date();
     }
 
     public void registerDiscovery() {

--- a/herald/src/main/java/com/vmware/herald/sensor/ble/BLESensorConfiguration.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/ble/BLESensorConfiguration.java
@@ -29,13 +29,31 @@ public class BLESensorConfiguration {
     /// Primary payload characteristic (read) for distributing payload data from peripheral to central, e.g. identity data
     /// - Characteristic UUID is randomly generated V4 UUIDs that has been tested for uniqueness by conducting web searches to ensure it returns no results.
     public final static UUID payloadCharacteristicUUID = UUID.fromString("3e98c0f8-8f05-4829-a121-43e38f8933e7");
-    /// Service and characteristic UUIDs for standard device services. These are fixed UUID from the BLE standard
-    /// Device characteristic for reading device model name
+
+    /// Standard Bluetooth service and characteristics
+    /// These are all fixed UUID from the BLE standard.
+    /// Standard Bluetooth Service UUID for Generic Access Service
+    /// - Service UUID from BLE standard
+    public final static UUID bluetoothGenericAccessServiceUUID = UUID.fromString("00001800-0000-1000-8000-00805f9b34fb");
+    /// Standard Bluetooth Characteristic UUID for Generic Access Service : Device Name
     /// - Characteristic UUID from BLE standard
-    public final static UUID modelCharacteristicUUID = UUID.fromString("00002a24-0000-1000-8000-00805f9b34fb");
-    /// Device characteristic for reading device name
+    public final static UUID bluetoothGenericAccessServiceDeviceNameCharacteristicUUID = UUID.fromString("00002a00-0000-1000-8000-00805f9b34fb");
+    /// Standard Bluetooth Characteristic UUID for Generic Access Service : Device Name
     /// - Characteristic UUID from BLE standard
-    public final static UUID deviceNameCharacteristicUUID = UUID.fromString("00002a00-0000-1000-8000-00805f9b34fb");
+    public final static UUID bluetoothGenericAccessServiceAppearanceCharacteristicUUID = UUID.fromString("00002a01-0000-1000-8000-00805f9b34fb");
+    /// Standard Bluetooth Service UUID for Device Information Service
+    /// - Service UUID from BLE standard
+    public final static UUID bluetoothDeviceInformationServiceUUID = UUID.fromString("0000180a-0000-1000-8000-00805f9b34fb");
+    /// Standard Bluetooth Characteristic UUID for Device Information Service : Model
+    /// - Characteristic UUID from BLE standard
+    public final static UUID bluetoothDeviceInformationServiceModelCharacteristicUUID = UUID.fromString("00002a24-0000-1000-8000-00805f9b34fb");
+    /// Standard Bluetooth Characteristic UUID for Device Information Service : Manufacturer
+    /// - Characteristic UUID from BLE standard
+    public final static UUID bluetoothDeviceInformationServiceManufacturerCharacteristicUUID = UUID.fromString("00002a29-0000-1000-8000-00805f9b34fb");
+    /// Standard Bluetooth Characteristic UUID for Device Information Service : TX Power
+    /// - Characteristic UUID from BLE standard
+    public final static UUID bluetoothDeviceInformationServiceTxPowerCharacteristicUUID = UUID.fromString("00002a07-0000-1000-8000-00805f9b34fb");
+
     /// Manufacturer data is being used on Android to store pseudo device address
     /// - Pending update to dedicated ID
     public final static int manufacturerIdForSensor = 65530;

--- a/herald/src/main/java/com/vmware/herald/sensor/ble/BLESensorConfiguration.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/ble/BLESensorConfiguration.java
@@ -59,8 +59,6 @@ public class BLESensorConfiguration {
     public final static int manufacturerIdForSensor = 65530;
     /// BLE advert manufacturer ID for Apple, for scanning of background iOS devices
     public final static int manufacturerIdForApple = 76;
-    // Whether we try to find a device make/model or not
-    public static boolean deviceIntrospectionEnabled = true;
 
     // MARK:- BLE signal characteristic action codes
 
@@ -105,4 +103,7 @@ public class BLESensorConfiguration {
 
     /// Advert refresh time interval
     public static TimeInterval advertRefreshTimeInterval = TimeInterval.minutes(15);
+
+    /// Interrogate standard Bluetooth services to obtain device make/model data
+    public static boolean deviceIntrospectionEnabled = false;
 }

--- a/herald/src/main/java/com/vmware/herald/sensor/ble/BLESensorConfiguration.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/ble/BLESensorConfiguration.java
@@ -29,10 +29,11 @@ public class BLESensorConfiguration {
     /// Primary payload characteristic (read) for distributing payload data from peripheral to central, e.g. identity data
     /// - Characteristic UUID is randomly generated V4 UUIDs that has been tested for uniqueness by conducting web searches to ensure it returns no results.
     public final static UUID payloadCharacteristicUUID = UUID.fromString("3e98c0f8-8f05-4829-a121-43e38f8933e7");
-    /// Characteristic for reading device modelName
+    /// Service and characteristic UUIDs for standard device services. These are fixed UUID from the BLE standard
+    /// Device characteristic for reading device model name
     /// - Characteristic UUID from BLE standard
     public final static UUID modelCharacteristicUUID = UUID.fromString("00002a24-0000-1000-8000-00805f9b34fb");
-    /// Characteristic for reading deviceName
+    /// Device characteristic for reading device name
     /// - Characteristic UUID from BLE standard
     public final static UUID deviceNameCharacteristicUUID = UUID.fromString("00002a00-0000-1000-8000-00805f9b34fb");
     /// Manufacturer data is being used on Android to store pseudo device address
@@ -41,7 +42,7 @@ public class BLESensorConfiguration {
     /// BLE advert manufacturer ID for Apple, for scanning of background iOS devices
     public final static int manufacturerIdForApple = 76;
     // Whether we try to find a device make/model or not
-    public static boolean deviceIntrospectionEnabled = false;
+    public static boolean deviceIntrospectionEnabled = true;
 
     // MARK:- BLE signal characteristic action codes
 

--- a/herald/src/main/java/com/vmware/herald/sensor/ble/ConcreteBLEReceiver.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/ble/ConcreteBLEReceiver.java
@@ -17,12 +17,13 @@ import android.bluetooth.le.ScanRecord;
 import android.bluetooth.le.ScanResult;
 import android.bluetooth.le.ScanSettings;
 import android.content.Context;
-import android.os.Build;
 import android.os.ParcelUuid;
 
+import com.vmware.herald.sensor.SensorDelegate;
+import com.vmware.herald.sensor.analysis.Sample;
+import com.vmware.herald.sensor.ble.filter.BLEAdvertParser;
 import com.vmware.herald.sensor.data.ConcreteSensorLogger;
 import com.vmware.herald.sensor.data.SensorLogger;
-import com.vmware.herald.sensor.datatype.Base64;
 import com.vmware.herald.sensor.datatype.BluetoothState;
 import com.vmware.herald.sensor.datatype.Callback;
 import com.vmware.herald.sensor.datatype.Data;
@@ -30,12 +31,10 @@ import com.vmware.herald.sensor.datatype.ImmediateSendData;
 import com.vmware.herald.sensor.datatype.PayloadData;
 import com.vmware.herald.sensor.datatype.PayloadSharingData;
 import com.vmware.herald.sensor.datatype.RSSI;
-import com.vmware.herald.sensor.analysis.Sample;
 import com.vmware.herald.sensor.datatype.SignalCharacteristicData;
 import com.vmware.herald.sensor.datatype.SignalCharacteristicDataType;
 import com.vmware.herald.sensor.datatype.TargetIdentifier;
 import com.vmware.herald.sensor.datatype.TimeInterval;
-import com.vmware.herald.sensor.SensorDelegate;
 
 import java.util.ArrayList;
 import java.util.HashSet;

--- a/herald/src/main/java/com/vmware/herald/sensor/ble/filter/BLEAdvertManufacturerData.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/ble/filter/BLEAdvertManufacturerData.java
@@ -2,7 +2,7 @@
 //  SPDX-License-Identifier: MIT
 //
 
-package com.vmware.herald.sensor.ble;
+package com.vmware.herald.sensor.ble.filter;
 
 public class BLEAdvertManufacturerData {
     public int manufacturer;

--- a/herald/src/main/java/com/vmware/herald/sensor/ble/filter/BLEAdvertParser.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/ble/filter/BLEAdvertParser.java
@@ -2,12 +2,10 @@
 //  SPDX-License-Identifier: MIT
 //
 
-package com.vmware.herald.sensor.ble;
+package com.vmware.herald.sensor.ble.filter;
 
 import com.vmware.herald.sensor.datatype.UInt8;
 
-import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
 import java.util.List;
 import java.util.ArrayList;
 

--- a/herald/src/main/java/com/vmware/herald/sensor/ble/filter/BLEAdvertSegment.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/ble/filter/BLEAdvertSegment.java
@@ -2,7 +2,7 @@
 //  SPDX-License-Identifier: MIT
 //
 
-package com.vmware.herald.sensor.ble;
+package com.vmware.herald.sensor.ble.filter;
 
 public class BLEAdvertSegment {
     public BLEAdvertSegmentType type;

--- a/herald/src/main/java/com/vmware/herald/sensor/ble/filter/BLEAdvertSegmentType.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/ble/filter/BLEAdvertSegmentType.java
@@ -2,9 +2,7 @@
 //  SPDX-License-Identifier: MIT
 //
 
-package com.vmware.herald.sensor.ble;
-
-import com.vmware.herald.sensor.datatype.UInt8;
+package com.vmware.herald.sensor.ble.filter;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/herald/src/main/java/com/vmware/herald/sensor/ble/filter/BLEDeviceFilter.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/ble/filter/BLEDeviceFilter.java
@@ -2,11 +2,13 @@
 //  SPDX-License-Identifier: MIT
 //
 
-package com.vmware.herald.sensor.ble;
+package com.vmware.herald.sensor.ble.filter;
 
 import android.bluetooth.le.ScanRecord;
 import android.content.Context;
 
+import com.vmware.herald.sensor.ble.BLEDevice;
+import com.vmware.herald.sensor.ble.BLESensorConfiguration;
 import com.vmware.herald.sensor.data.ConcreteSensorLogger;
 import com.vmware.herald.sensor.data.SensorLogger;
 import com.vmware.herald.sensor.data.TextFile;

--- a/herald/src/main/java/com/vmware/herald/sensor/ble/filter/BLEScanResponseData.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/ble/filter/BLEScanResponseData.java
@@ -2,7 +2,7 @@
 //  SPDX-License-Identifier: MIT
 //
 
-package com.vmware.herald.sensor.ble;
+package com.vmware.herald.sensor.ble.filter;
 
 import java.util.List;
 

--- a/herald/src/main/java/com/vmware/herald/sensor/data/ConcreteSensorLogger.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/data/ConcreteSensorLogger.java
@@ -31,6 +31,9 @@ public class ConcreteSensorLogger implements SensorLogger {
     }
 
     private boolean suppress(SensorLoggerLevel level) {
+        if (BLESensorConfiguration.logLevel == SensorLoggerLevel.off) {
+            return true;
+        }
         switch (level) {
             case debug:
                 return (BLESensorConfiguration.logLevel == SensorLoggerLevel.info || BLESensorConfiguration.logLevel == SensorLoggerLevel.fault);

--- a/herald/src/main/java/com/vmware/herald/sensor/data/SensorLoggerLevel.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/data/SensorLoggerLevel.java
@@ -5,5 +5,5 @@
 package com.vmware.herald.sensor.data;
 
 public enum SensorLoggerLevel {
-    debug, info, fault
+    off, debug, info, fault
 }

--- a/herald/src/test/java/com/vmware/herald/sensor/ble/AdvertParserTests.java
+++ b/herald/src/test/java/com/vmware/herald/sensor/ble/AdvertParserTests.java
@@ -4,11 +4,12 @@
 
 package com.vmware.herald.sensor.ble;
 
+import com.vmware.herald.sensor.ble.filter.BLEAdvertManufacturerData;
+import com.vmware.herald.sensor.ble.filter.BLEAdvertParser;
+import com.vmware.herald.sensor.ble.filter.BLEScanResponseData;
+
 import org.junit.Test;
 
-import java.nio.ByteBuffer;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;


### PR DESCRIPTION
- Updated optional support for standard bluetooth services (disabled by default)
- Relaxed connection retry logic to only ignore devices not advertising sensor services for a limited time before retry
- Inspected payload sharing code to confirm de-duplication logic is correct, observed duplicates are likely to be corrupted payload data (code de-duplicates by raw data, maybe tail end of payload data has been corrupted).
- Refactored experimental and unused BLE filter code to sensor.ble.filter pending further development in next version.  
- Updated UI to show read, measure time interval statistics.
- Tested on:
    - Pixel 2 (Android 10, weak BLE transceiver)
    - Samsung A10 (Android 9, rapid address change)
    - Samsung A20 (Android 10, rapid address change)
    - Samsung J6 (Android 9, non-advertising)
    - (with) iPhone 6s (iOS 12.1.4)

Closes #54 
Closes #55