### PR TITLE
Fixes #61. Moved to Apache-2.0 license

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,13 +1,207 @@
-herald-for-android
-Copyright 2020 VMware, Inc.
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
 
-The MIT license (the "License") set forth below applies to all parts of the herald-for-android project. You may not use this file except in compliance with the License.
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-MIT License
+1. Definitions.
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do
-so, subject to the following conditions:
+    "License" shall mean the terms and conditions for use, reproduction, and
+    distribution as defined by Sections 1 through 9 of this document.
 
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+    "Licensor" shall mean the copyright owner or entity authorized by the
+    copyright owner that is granting the License.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+    "Legal Entity" shall mean the union of the acting entity and all other
+    entities that control, are controlled by, or are under common control with
+    that entity. For the purposes of this definition, "control" means (i) the
+    power, direct or indirect, to cause the direction or management of such
+    entity, whether by contract or otherwise, or (ii) ownership of
+    fifty percent (50%) or more of the outstanding shares, or (iii) beneficial
+    ownership of such entity.
+
+    "You" (or "Your") shall mean an individual or Legal Entity exercising
+    permissions granted by this License.
+
+    "Source" form shall mean the preferred form for making modifications,
+    including but not limited to software source code, documentation source,
+    and configuration files.
+
+    "Object" form shall mean any form resulting from mechanical transformation
+    or translation of a Source form, including but not limited to compiled
+    object code, generated documentation, and conversions to
+    other media types.
+
+    "Work" shall mean the work of authorship, whether in Source or Object
+    form, made available under the License, as indicated by a copyright notice
+    that is included in or attached to the work (an example is provided in the
+    Appendix below).
+
+    "Derivative Works" shall mean any work, whether in Source or Object form,
+    that is based on (or derived from) the Work and for which the editorial
+    revisions, annotations, elaborations, or other modifications represent,
+    as a whole, an original work of authorship. For the purposes of this
+    License, Derivative Works shall not include works that remain separable
+    from, or merely link (or bind by name) to the interfaces of, the Work and
+    Derivative Works thereof.
+
+    "Contribution" shall mean any work of authorship, including the original
+    version of the Work and any modifications or additions to that Work or
+    Derivative Works thereof, that is intentionally submitted to Licensor for
+    inclusion in the Work by the copyright owner or by an individual or
+    Legal Entity authorized to submit on behalf of the copyright owner.
+    For the purposes of this definition, "submitted" means any form of
+    electronic, verbal, or written communication sent to the Licensor or its
+    representatives, including but not limited to communication on electronic
+    mailing lists, source code control systems, and issue tracking systems
+    that are managed by, or on behalf of, the Licensor for the purpose of
+    discussing and improving the Work, but excluding communication that is
+    conspicuously marked or otherwise designated in writing by the copyright
+    owner as "Not a Contribution."
+
+    "Contributor" shall mean Licensor and any individual or Legal Entity on
+    behalf of whom a Contribution has been received by Licensor and
+    subsequently incorporated within the Work.
+
+2. Grant of Copyright License.
+
+    Subject to the terms and conditions of this License, each Contributor
+    hereby grants to You a perpetual, worldwide, non-exclusive, no-charge,
+    royalty-free, irrevocable copyright license to reproduce, prepare
+    Derivative Works of, publicly display, publicly perform, sublicense,
+    and distribute the Work and such Derivative Works in
+    Source or Object form.
+
+3. Grant of Patent License.
+
+    Subject to the terms and conditions of this License, each Contributor
+    hereby grants to You a perpetual, worldwide, non-exclusive, no-charge,
+    royalty-free, irrevocable (except as stated in this section) patent
+    license to make, have made, use, offer to sell, sell, import, and
+    otherwise transfer the Work, where such license applies only to those
+    patent claims licensable by such Contributor that are necessarily
+    infringed by their Contribution(s) alone or by combination of their
+    Contribution(s) with the Work to which such Contribution(s) was submitted.
+    If You institute patent litigation against any entity (including a
+    cross-claim or counterclaim in a lawsuit) alleging that the Work or a
+    Contribution incorporated within the Work constitutes direct or
+    contributory patent infringement, then any patent licenses granted to
+    You under this License for that Work shall terminate as of the date such
+    litigation is filed.
+
+4. Redistribution.
+
+    You may reproduce and distribute copies of the Work or Derivative Works
+    thereof in any medium, with or without modifications, and in Source or
+    Object form, provided that You meet the following conditions:
+
+    1. You must give any other recipients of the Work or Derivative Works a
+    copy of this License; and
+
+    2. You must cause any modified files to carry prominent notices stating
+    that You changed the files; and
+
+    3. You must retain, in the Source form of any Derivative Works that You
+    distribute, all copyright, patent, trademark, and attribution notices from
+    the Source form of the Work, excluding those notices that do not pertain
+    to any part of the Derivative Works; and
+
+    4. If the Work includes a "NOTICE" text file as part of its distribution,
+    then any Derivative Works that You distribute must include a readable copy
+    of the attribution notices contained within such NOTICE file, excluding
+    those notices that do not pertain to any part of the Derivative Works,
+    in at least one of the following places: within a NOTICE text file
+    distributed as part of the Derivative Works; within the Source form or
+    documentation, if provided along with the Derivative Works; or, within a
+    display generated by the Derivative Works, if and wherever such
+    third-party notices normally appear. The contents of the NOTICE file are
+    for informational purposes only and do not modify the License.
+    You may add Your own attribution notices within Derivative Works that You
+    distribute, alongside or as an addendum to the NOTICE text from the Work,
+    provided that such additional attribution notices cannot be construed
+    as modifying the License.
+
+    You may add Your own copyright statement to Your modifications and may
+    provide additional or different license terms and conditions for use,
+    reproduction, or distribution of Your modifications, or for any such
+    Derivative Works as a whole, provided Your use, reproduction, and
+    distribution of the Work otherwise complies with the conditions
+    stated in this License.
+
+5. Submission of Contributions.
+
+    Unless You explicitly state otherwise, any Contribution intentionally
+    submitted for inclusion in the Work by You to the Licensor shall be under
+    the terms and conditions of this License, without any additional
+    terms or conditions. Notwithstanding the above, nothing herein shall
+    supersede or modify the terms of any separate license agreement you may
+    have executed with Licensor regarding such Contributions.
+
+6. Trademarks.
+
+    This License does not grant permission to use the trade names, trademarks,
+    service marks, or product names of the Licensor, except as required for
+    reasonable and customary use in describing the origin of the Work and
+    reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty.
+
+    Unless required by applicable law or agreed to in writing, Licensor
+    provides the Work (and each Contributor provides its Contributions)
+    on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+    either express or implied, including, without limitation, any warranties
+    or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS
+    FOR A PARTICULAR PURPOSE. You are solely responsible for determining the
+    appropriateness of using or redistributing the Work and assume any risks
+    associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability.
+
+    In no event and under no legal theory, whether in tort
+    (including negligence), contract, or otherwise, unless required by
+    applicable law (such as deliberate and grossly negligent acts) or agreed
+    to in writing, shall any Contributor be liable to You for damages,
+    including any direct, indirect, special, incidental, or consequential
+    damages of any character arising as a result of this License or out of
+    the use or inability to use the Work (including but not limited to damages
+    for loss of goodwill, work stoppage, computer failure or malfunction,
+    or any and all other commercial damages or losses), even if such
+    Contributor has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability.
+
+    While redistributing the Work or Derivative Works thereof, You may choose
+    to offer, and charge a fee for, acceptance of support, warranty,
+    indemnity, or other liability obligations and/or rights consistent with
+    this License. However, in accepting such obligations, You may act only
+    on Your own behalf and on Your sole responsibility, not on behalf of any
+    other Contributor, and only if You agree to indemnify, defend, and hold
+    each Contributor harmless for any liability incurred by, or claims
+    asserted against, such Contributor by reason of your accepting any such
+    warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work
+
+    To apply the Apache License to your work, attach the following boilerplate
+    notice, with the fields enclosed by brackets "[]" replaced with your own
+    identifying information. (Don't include the brackets!) The text should be
+    enclosed in the appropriate comment syntax for the file format. We also
+    recommend that a file or class name and description of purpose be included
+    on the same "printed page" as the copyright notice for easier
+    identification within third-party archives.
+
+        Copyright 2020 VMware, Inc.
+
+        Licensed under the Apache License, Version 2.0 (the "License");
+        you may not use this file except in compliance with the License.
+        You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+        or implied. See the License for the specific language governing
+        permissions and limitations under the License.

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,6 +1,6 @@
 herald-for-android
 Copyright 2020 VMware, Inc. 
 
-This product is licensed to you under the MIT license (the "License").  You may not use this product except in compliance with the MIT License.  
+This product is licensed to you under the Apache-2.0 license (the "License").  You may not use this product except in compliance with the Apache-2.0 License.  
 
 This product may include a number of subcomponents with separate copyright notices and license terms. Your use of these subcomponents is subject to the terms and conditions of the subcomponent's license, as noted in the LICENSE file. 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Continuous proximity detection across iOS and Android devices in background mode
 
 Copyright 2020 VMware, Inc.
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![License: Apache-2.0](https://img.shields.io/badge/License-Apache2.0-yellow.svg)](https://opensource.org/licenses/Apache-2.0)
 
 See LICENSE.txt and NOTICE.txt for details.
 
@@ -42,13 +42,13 @@ This is a new, original, free and open source cross-platform proximity detection
 - One or more distance measurement per 30 second window for devices within epidemiologically relevant range (8 metres) for accurate infection risk estimation and case isolation; coverage is > 99.5% of 30 second windows for 2 to 3 devices, and 93% - 96% of windows for 9 to 10 devices.
 - RSSI measurements for distance estimation is 98.5% accurate within epidemiologically relevant range (8 metres).
 - Device identification payload agnostic to support both centralised, and decentralised approaches, as well as retrospective integration into existing solutions.
-- MIT license and open source for ease of integration, reuse and transparency.
+- Apache-2.0 licensed and open source for ease of integration, reuse and transparency.
 
 ## Hardware requirements
 
 - Operating system
 
-  - iOS 9.3+, tested up to iOS 13.7.
+  - iOS 9.3+, tested up to iOS 14.2.
   - Android 5.0+, tested up to Android 10.0 (API level 29).
 
 - Hardware
@@ -62,7 +62,7 @@ You will need the following items for evaluation (some of our tested versions in
 
 - Hardware
   - Apple computer (MacBook Pro Late 2013 to Late 2019) running macOS Catalina (10.15.4).
-  - One or more Apple iPhones (iPhone 4S, SE, 5, 6, 7, X, 11) running iOS (9.3 to 13.7).
+  - One or more Apple iPhones (iPhone 4S, SE, 5, 6, 7, X, 11) running iOS (9.3 to 14.2).
   - One or more Android phones (Samsung A10, A20, A70, J6, S10) running Android (8.0 to 10.0).
 - Software
   - Xcode (11.7) for building and deploying the iOS app to test devices.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,5 +1,5 @@
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 apply plugin: 'com.android.application'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <!-- Copyright 2020 VMware, Inc. -->
-<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.vmware.herald.app">

--- a/app/src/main/java/com/vmware/herald/app/AppDelegate.java
+++ b/app/src/main/java/com/vmware/herald/app/AppDelegate.java
@@ -1,5 +1,5 @@
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 package com.vmware.herald.app;

--- a/app/src/main/java/com/vmware/herald/app/MainActivity.java
+++ b/app/src/main/java/com/vmware/herald/app/MainActivity.java
@@ -1,5 +1,5 @@
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 package com.vmware.herald.app;

--- a/app/src/main/java/com/vmware/herald/app/Target.java
+++ b/app/src/main/java/com/vmware/herald/app/Target.java
@@ -1,5 +1,5 @@
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 package com.vmware.herald.app;

--- a/app/src/main/java/com/vmware/herald/app/TargetListAdapter.java
+++ b/app/src/main/java/com/vmware/herald/app/TargetListAdapter.java
@@ -1,5 +1,5 @@
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 package com.vmware.herald.app;

--- a/app/src/main/res/drawable-v24/ic_launcher_foreground.xml
+++ b/app/src/main/res/drawable-v24/ic_launcher_foreground.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <!-- Copyright 2020 VMware, Inc. -->
-<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
 
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:aapt="http://schemas.android.com/aapt"

--- a/app/src/main/res/drawable/ic_launcher_background.xml
+++ b/app/src/main/res/drawable/ic_launcher_background.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <!-- Copyright 2020 VMware, Inc. -->
-<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
 
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="108dp"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <!-- Copyright 2020 VMware, Inc. -->
-<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
 
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"

--- a/app/src/main/res/layout/listview_targets_row.xml
+++ b/app/src/main/res/layout/listview_targets_row.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <!-- Copyright 2020 VMware, Inc. -->
-<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <!-- Copyright 2020 VMware, Inc. -->
-<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
 
 <resources>
     <color name="colorPrimary">#6200EE</color>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <!-- Copyright 2020 VMware, Inc. -->
-<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
 
 <resources>
     <string name="app_name">Herald-for-Android</string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <!-- Copyright 2020 VMware, Inc. -->
-<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
 
 <resources>
     <!-- Base application theme. -->

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 // Top-level build file where you can add configuration options common to all sub-projects/modules.

--- a/herald/src/main/java/com/vmware/herald/sensor/DefaultSensorDelegate.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/DefaultSensorDelegate.java
@@ -1,5 +1,5 @@
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 package com.vmware.herald.sensor;

--- a/herald/src/main/java/com/vmware/herald/sensor/PayloadDataSupplier.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/PayloadDataSupplier.java
@@ -1,5 +1,5 @@
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 package com.vmware.herald.sensor;

--- a/herald/src/main/java/com/vmware/herald/sensor/Sensor.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/Sensor.java
@@ -1,5 +1,5 @@
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 package com.vmware.herald.sensor;

--- a/herald/src/main/java/com/vmware/herald/sensor/SensorArray.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/SensorArray.java
@@ -1,5 +1,5 @@
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 package com.vmware.herald.sensor;

--- a/herald/src/main/java/com/vmware/herald/sensor/SensorDelegate.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/SensorDelegate.java
@@ -1,5 +1,5 @@
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 package com.vmware.herald.sensor;

--- a/herald/src/main/java/com/vmware/herald/sensor/analysis/Interactions.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/analysis/Interactions.java
@@ -1,5 +1,5 @@
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 package com.vmware.herald.sensor.analysis;

--- a/herald/src/main/java/com/vmware/herald/sensor/analysis/Sample.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/analysis/Sample.java
@@ -1,5 +1,5 @@
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 package com.vmware.herald.sensor.analysis;

--- a/herald/src/main/java/com/vmware/herald/sensor/analysis/SocialDistance.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/analysis/SocialDistance.java
@@ -1,5 +1,5 @@
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 package com.vmware.herald.sensor.analysis;

--- a/herald/src/main/java/com/vmware/herald/sensor/ble/BLEDatabase.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/ble/BLEDatabase.java
@@ -1,5 +1,5 @@
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 package com.vmware.herald.sensor.ble;

--- a/herald/src/main/java/com/vmware/herald/sensor/ble/BLEDatabaseDelegate.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/ble/BLEDatabaseDelegate.java
@@ -1,5 +1,5 @@
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 package com.vmware.herald.sensor.ble;

--- a/herald/src/main/java/com/vmware/herald/sensor/ble/BLEDevice.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/ble/BLEDevice.java
@@ -1,5 +1,5 @@
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 package com.vmware.herald.sensor.ble;

--- a/herald/src/main/java/com/vmware/herald/sensor/ble/BLEDeviceAttribute.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/ble/BLEDeviceAttribute.java
@@ -1,5 +1,5 @@
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 package com.vmware.herald.sensor.ble;

--- a/herald/src/main/java/com/vmware/herald/sensor/ble/BLEDeviceDelegate.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/ble/BLEDeviceDelegate.java
@@ -1,5 +1,5 @@
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 package com.vmware.herald.sensor.ble;

--- a/herald/src/main/java/com/vmware/herald/sensor/ble/BLEDeviceOperatingSystem.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/ble/BLEDeviceOperatingSystem.java
@@ -1,5 +1,5 @@
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 package com.vmware.herald.sensor.ble;

--- a/herald/src/main/java/com/vmware/herald/sensor/ble/BLEDeviceState.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/ble/BLEDeviceState.java
@@ -1,5 +1,5 @@
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 package com.vmware.herald.sensor.ble;

--- a/herald/src/main/java/com/vmware/herald/sensor/ble/BLEReceiver.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/ble/BLEReceiver.java
@@ -1,5 +1,5 @@
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 package com.vmware.herald.sensor.ble;

--- a/herald/src/main/java/com/vmware/herald/sensor/ble/BLESensor.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/ble/BLESensor.java
@@ -1,5 +1,5 @@
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 package com.vmware.herald.sensor.ble;

--- a/herald/src/main/java/com/vmware/herald/sensor/ble/BLESensorConfiguration.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/ble/BLESensorConfiguration.java
@@ -1,5 +1,5 @@
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 package com.vmware.herald.sensor.ble;

--- a/herald/src/main/java/com/vmware/herald/sensor/ble/BLETimer.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/ble/BLETimer.java
@@ -1,5 +1,5 @@
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 package com.vmware.herald.sensor.ble;

--- a/herald/src/main/java/com/vmware/herald/sensor/ble/BLETimerDelegate.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/ble/BLETimerDelegate.java
@@ -1,5 +1,5 @@
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 package com.vmware.herald.sensor.ble;

--- a/herald/src/main/java/com/vmware/herald/sensor/ble/BLETransmitter.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/ble/BLETransmitter.java
@@ -1,5 +1,5 @@
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 package com.vmware.herald.sensor.ble;

--- a/herald/src/main/java/com/vmware/herald/sensor/ble/BLE_TxPower.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/ble/BLE_TxPower.java
@@ -1,5 +1,5 @@
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 package com.vmware.herald.sensor.ble;

--- a/herald/src/main/java/com/vmware/herald/sensor/ble/BluetoothStateManager.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/ble/BluetoothStateManager.java
@@ -1,5 +1,5 @@
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 package com.vmware.herald.sensor.ble;

--- a/herald/src/main/java/com/vmware/herald/sensor/ble/BluetoothStateManagerDelegate.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/ble/BluetoothStateManagerDelegate.java
@@ -1,5 +1,5 @@
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 package com.vmware.herald.sensor.ble;

--- a/herald/src/main/java/com/vmware/herald/sensor/ble/ConcreteBLEDatabase.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/ble/ConcreteBLEDatabase.java
@@ -1,5 +1,5 @@
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 package com.vmware.herald.sensor.ble;

--- a/herald/src/main/java/com/vmware/herald/sensor/ble/ConcreteBLEReceiver.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/ble/ConcreteBLEReceiver.java
@@ -1,5 +1,5 @@
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 package com.vmware.herald.sensor.ble;

--- a/herald/src/main/java/com/vmware/herald/sensor/ble/ConcreteBLESensor.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/ble/ConcreteBLESensor.java
@@ -1,5 +1,5 @@
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 package com.vmware.herald.sensor.ble;

--- a/herald/src/main/java/com/vmware/herald/sensor/ble/ConcreteBLETransmitter.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/ble/ConcreteBLETransmitter.java
@@ -1,5 +1,5 @@
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 package com.vmware.herald.sensor.ble;

--- a/herald/src/main/java/com/vmware/herald/sensor/ble/ConcreteBluetoothStateManager.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/ble/ConcreteBluetoothStateManager.java
@@ -1,5 +1,5 @@
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 package com.vmware.herald.sensor.ble;

--- a/herald/src/main/java/com/vmware/herald/sensor/ble/filter/BLEAdvertAppleManufacturerSegment.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/ble/filter/BLEAdvertAppleManufacturerSegment.java
@@ -1,5 +1,5 @@
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 package com.vmware.herald.sensor.ble.filter;

--- a/herald/src/main/java/com/vmware/herald/sensor/ble/filter/BLEAdvertManufacturerData.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/ble/filter/BLEAdvertManufacturerData.java
@@ -1,5 +1,5 @@
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 package com.vmware.herald.sensor.ble.filter;

--- a/herald/src/main/java/com/vmware/herald/sensor/ble/filter/BLEAdvertParser.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/ble/filter/BLEAdvertParser.java
@@ -1,5 +1,5 @@
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 package com.vmware.herald.sensor.ble.filter;

--- a/herald/src/main/java/com/vmware/herald/sensor/ble/filter/BLEAdvertSegment.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/ble/filter/BLEAdvertSegment.java
@@ -1,5 +1,5 @@
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 package com.vmware.herald.sensor.ble.filter;

--- a/herald/src/main/java/com/vmware/herald/sensor/ble/filter/BLEAdvertSegmentType.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/ble/filter/BLEAdvertSegmentType.java
@@ -1,5 +1,5 @@
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 package com.vmware.herald.sensor.ble.filter;

--- a/herald/src/main/java/com/vmware/herald/sensor/ble/filter/BLEDeviceFilter.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/ble/filter/BLEDeviceFilter.java
@@ -1,5 +1,5 @@
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 package com.vmware.herald.sensor.ble.filter;

--- a/herald/src/main/java/com/vmware/herald/sensor/ble/filter/BLEScanResponseData.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/ble/filter/BLEScanResponseData.java
@@ -1,5 +1,5 @@
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 package com.vmware.herald.sensor.ble.filter;

--- a/herald/src/main/java/com/vmware/herald/sensor/data/BatteryLog.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/data/BatteryLog.java
@@ -1,5 +1,5 @@
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 package com.vmware.herald.sensor.data;

--- a/herald/src/main/java/com/vmware/herald/sensor/data/ConcreteSensorLogger.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/data/ConcreteSensorLogger.java
@@ -1,5 +1,5 @@
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 package com.vmware.herald.sensor.data;

--- a/herald/src/main/java/com/vmware/herald/sensor/data/ContactLog.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/data/ContactLog.java
@@ -1,5 +1,5 @@
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 package com.vmware.herald.sensor.data;

--- a/herald/src/main/java/com/vmware/herald/sensor/data/DetectionLog.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/data/DetectionLog.java
@@ -1,5 +1,5 @@
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 package com.vmware.herald.sensor.data;

--- a/herald/src/main/java/com/vmware/herald/sensor/data/SensorLogger.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/data/SensorLogger.java
@@ -1,5 +1,5 @@
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 package com.vmware.herald.sensor.data;

--- a/herald/src/main/java/com/vmware/herald/sensor/data/SensorLoggerLevel.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/data/SensorLoggerLevel.java
@@ -1,5 +1,5 @@
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 package com.vmware.herald.sensor.data;

--- a/herald/src/main/java/com/vmware/herald/sensor/data/StatisticsDidReadLog.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/data/StatisticsDidReadLog.java
@@ -1,5 +1,5 @@
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 package com.vmware.herald.sensor.data;

--- a/herald/src/main/java/com/vmware/herald/sensor/data/StatisticsLog.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/data/StatisticsLog.java
@@ -1,5 +1,5 @@
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 package com.vmware.herald.sensor.data;

--- a/herald/src/main/java/com/vmware/herald/sensor/data/TextFile.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/data/TextFile.java
@@ -1,5 +1,5 @@
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 package com.vmware.herald.sensor.data;

--- a/herald/src/main/java/com/vmware/herald/sensor/datatype/Base64.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/datatype/Base64.java
@@ -1,5 +1,5 @@
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 package com.vmware.herald.sensor.datatype;

--- a/herald/src/main/java/com/vmware/herald/sensor/datatype/BluetoothState.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/datatype/BluetoothState.java
@@ -1,5 +1,5 @@
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 package com.vmware.herald.sensor.datatype;

--- a/herald/src/main/java/com/vmware/herald/sensor/datatype/Calibration.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/datatype/Calibration.java
@@ -1,5 +1,5 @@
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 package com.vmware.herald.sensor.datatype;

--- a/herald/src/main/java/com/vmware/herald/sensor/datatype/CalibrationMeasurementUnit.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/datatype/CalibrationMeasurementUnit.java
@@ -1,5 +1,5 @@
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 package com.vmware.herald.sensor.datatype;

--- a/herald/src/main/java/com/vmware/herald/sensor/datatype/Callback.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/datatype/Callback.java
@@ -1,5 +1,5 @@
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 package com.vmware.herald.sensor.datatype;

--- a/herald/src/main/java/com/vmware/herald/sensor/datatype/Data.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/datatype/Data.java
@@ -1,5 +1,5 @@
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 package com.vmware.herald.sensor.datatype;

--- a/herald/src/main/java/com/vmware/herald/sensor/datatype/Encounter.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/datatype/Encounter.java
@@ -1,5 +1,5 @@
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 package com.vmware.herald.sensor.datatype;

--- a/herald/src/main/java/com/vmware/herald/sensor/datatype/Float16.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/datatype/Float16.java
@@ -1,3 +1,7 @@
+//  Copyright 2020 VMware, Inc.
+//  SPDX-License-Identifier: Apache-2.0
+//
+
 package com.vmware.herald.sensor.datatype;
 
 import java.nio.ByteBuffer;

--- a/herald/src/main/java/com/vmware/herald/sensor/datatype/ImmediateSendData.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/datatype/ImmediateSendData.java
@@ -1,5 +1,5 @@
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 package com.vmware.herald.sensor.datatype;

--- a/herald/src/main/java/com/vmware/herald/sensor/datatype/Location.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/datatype/Location.java
@@ -1,5 +1,5 @@
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 package com.vmware.herald.sensor.datatype;

--- a/herald/src/main/java/com/vmware/herald/sensor/datatype/LocationReference.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/datatype/LocationReference.java
@@ -1,5 +1,5 @@
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 package com.vmware.herald.sensor.datatype;

--- a/herald/src/main/java/com/vmware/herald/sensor/datatype/PayloadData.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/datatype/PayloadData.java
@@ -1,5 +1,5 @@
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 package com.vmware.herald.sensor.datatype;

--- a/herald/src/main/java/com/vmware/herald/sensor/datatype/PayloadSharingData.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/datatype/PayloadSharingData.java
@@ -1,5 +1,5 @@
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 package com.vmware.herald.sensor.datatype;

--- a/herald/src/main/java/com/vmware/herald/sensor/datatype/PayloadTimestamp.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/datatype/PayloadTimestamp.java
@@ -1,5 +1,5 @@
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 package com.vmware.herald.sensor.datatype;

--- a/herald/src/main/java/com/vmware/herald/sensor/datatype/PlacenameLocationReference.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/datatype/PlacenameLocationReference.java
@@ -1,5 +1,5 @@
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 package com.vmware.herald.sensor.datatype;

--- a/herald/src/main/java/com/vmware/herald/sensor/datatype/Proximity.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/datatype/Proximity.java
@@ -1,5 +1,5 @@
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 package com.vmware.herald.sensor.datatype;

--- a/herald/src/main/java/com/vmware/herald/sensor/datatype/ProximityMeasurementUnit.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/datatype/ProximityMeasurementUnit.java
@@ -1,5 +1,5 @@
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 package com.vmware.herald.sensor.datatype;

--- a/herald/src/main/java/com/vmware/herald/sensor/datatype/PseudoDeviceAddress.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/datatype/PseudoDeviceAddress.java
@@ -1,5 +1,5 @@
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 package com.vmware.herald.sensor.datatype;

--- a/herald/src/main/java/com/vmware/herald/sensor/datatype/RSSI.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/datatype/RSSI.java
@@ -1,5 +1,5 @@
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 package com.vmware.herald.sensor.datatype;

--- a/herald/src/main/java/com/vmware/herald/sensor/datatype/SensorState.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/datatype/SensorState.java
@@ -1,5 +1,5 @@
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 package com.vmware.herald.sensor.datatype;

--- a/herald/src/main/java/com/vmware/herald/sensor/datatype/SensorType.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/datatype/SensorType.java
@@ -1,5 +1,5 @@
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 package com.vmware.herald.sensor.datatype;

--- a/herald/src/main/java/com/vmware/herald/sensor/datatype/SignalCharacteristicData.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/datatype/SignalCharacteristicData.java
@@ -1,5 +1,5 @@
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 package com.vmware.herald.sensor.datatype;

--- a/herald/src/main/java/com/vmware/herald/sensor/datatype/SignalCharacteristicDataType.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/datatype/SignalCharacteristicDataType.java
@@ -1,5 +1,5 @@
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 package com.vmware.herald.sensor.datatype;

--- a/herald/src/main/java/com/vmware/herald/sensor/datatype/TargetIdentifier.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/datatype/TargetIdentifier.java
@@ -1,5 +1,5 @@
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 package com.vmware.herald.sensor.datatype;

--- a/herald/src/main/java/com/vmware/herald/sensor/datatype/TimeInterval.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/datatype/TimeInterval.java
@@ -1,5 +1,5 @@
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 package com.vmware.herald.sensor.datatype;

--- a/herald/src/main/java/com/vmware/herald/sensor/datatype/Triple.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/datatype/Triple.java
@@ -1,5 +1,5 @@
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 package com.vmware.herald.sensor.datatype;

--- a/herald/src/main/java/com/vmware/herald/sensor/datatype/Tuple.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/datatype/Tuple.java
@@ -1,5 +1,5 @@
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 package com.vmware.herald.sensor.datatype;

--- a/herald/src/main/java/com/vmware/herald/sensor/datatype/UInt16.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/datatype/UInt16.java
@@ -1,3 +1,7 @@
+//  Copyright 2020 VMware, Inc.
+//  SPDX-License-Identifier: Apache-2.0
+//
+
 package com.vmware.herald.sensor.datatype;
 
 import java.nio.ByteBuffer;

--- a/herald/src/main/java/com/vmware/herald/sensor/datatype/UInt8.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/datatype/UInt8.java
@@ -1,3 +1,7 @@
+//  Copyright 2020 VMware, Inc.
+//  SPDX-License-Identifier: Apache-2.0
+//
+
 package com.vmware.herald.sensor.datatype;
 
 import java.nio.ByteBuffer;

--- a/herald/src/main/java/com/vmware/herald/sensor/datatype/WGS84CircularAreaLocationReference.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/datatype/WGS84CircularAreaLocationReference.java
@@ -1,5 +1,5 @@
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 package com.vmware.herald.sensor.datatype;

--- a/herald/src/main/java/com/vmware/herald/sensor/datatype/WGS84PointLocationReference.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/datatype/WGS84PointLocationReference.java
@@ -1,5 +1,5 @@
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 package com.vmware.herald.sensor.datatype;

--- a/herald/src/main/java/com/vmware/herald/sensor/payload/DefaultPayloadDataSupplier.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/payload/DefaultPayloadDataSupplier.java
@@ -1,5 +1,5 @@
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 package com.vmware.herald.sensor.payload;

--- a/herald/src/main/java/com/vmware/herald/sensor/payload/c19x/BeaconCode.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/payload/c19x/BeaconCode.java
@@ -1,5 +1,5 @@
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 package com.vmware.herald.sensor.payload.c19x;

--- a/herald/src/main/java/com/vmware/herald/sensor/payload/c19x/BeaconCodeSeed.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/payload/c19x/BeaconCodeSeed.java
@@ -1,5 +1,5 @@
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 package com.vmware.herald.sensor.payload.c19x;

--- a/herald/src/main/java/com/vmware/herald/sensor/payload/c19x/BeaconCodes.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/payload/c19x/BeaconCodes.java
@@ -1,5 +1,5 @@
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 package com.vmware.herald.sensor.payload.c19x;

--- a/herald/src/main/java/com/vmware/herald/sensor/payload/c19x/C19XPayloadDataSupplier.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/payload/c19x/C19XPayloadDataSupplier.java
@@ -1,5 +1,5 @@
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 package com.vmware.herald.sensor.payload.c19x;

--- a/herald/src/main/java/com/vmware/herald/sensor/payload/c19x/ConcreteBeaconCodes.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/payload/c19x/ConcreteBeaconCodes.java
@@ -1,5 +1,5 @@
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 package com.vmware.herald.sensor.payload.c19x;

--- a/herald/src/main/java/com/vmware/herald/sensor/payload/c19x/ConcreteDayCodes.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/payload/c19x/ConcreteDayCodes.java
@@ -1,5 +1,5 @@
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 package com.vmware.herald.sensor.payload.c19x;

--- a/herald/src/main/java/com/vmware/herald/sensor/payload/c19x/Day.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/payload/c19x/Day.java
@@ -1,5 +1,5 @@
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 package com.vmware.herald.sensor.payload.c19x;

--- a/herald/src/main/java/com/vmware/herald/sensor/payload/c19x/DayCode.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/payload/c19x/DayCode.java
@@ -1,5 +1,5 @@
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 package com.vmware.herald.sensor.payload.c19x;

--- a/herald/src/main/java/com/vmware/herald/sensor/payload/c19x/DayCodes.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/payload/c19x/DayCodes.java
@@ -1,5 +1,5 @@
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 package com.vmware.herald.sensor.payload.c19x;

--- a/herald/src/main/java/com/vmware/herald/sensor/payload/c19x/JavaData.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/payload/c19x/JavaData.java
@@ -1,5 +1,5 @@
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 package com.vmware.herald.sensor.payload.c19x;

--- a/herald/src/main/java/com/vmware/herald/sensor/payload/c19x/SharedSecret.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/payload/c19x/SharedSecret.java
@@ -1,5 +1,5 @@
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 package com.vmware.herald.sensor.payload.c19x;

--- a/herald/src/main/java/com/vmware/herald/sensor/payload/c19x/Timestamp.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/payload/c19x/Timestamp.java
@@ -1,5 +1,5 @@
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 package com.vmware.herald.sensor.payload.c19x;

--- a/herald/src/main/java/com/vmware/herald/sensor/payload/simple/ConcreteSimplePayloadDataSupplier.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/payload/simple/ConcreteSimplePayloadDataSupplier.java
@@ -1,3 +1,7 @@
+//  Copyright 2020 VMware, Inc.
+//  SPDX-License-Identifier: Apache-2.0
+//
+
 package com.vmware.herald.sensor.payload.simple;
 
 import com.vmware.herald.sensor.data.ConcreteSensorLogger;

--- a/herald/src/main/java/com/vmware/herald/sensor/payload/simple/ContactIdentifier.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/payload/simple/ContactIdentifier.java
@@ -1,3 +1,7 @@
+//  Copyright 2020 VMware, Inc.
+//  SPDX-License-Identifier: Apache-2.0
+//
+
 package com.vmware.herald.sensor.payload.simple;
 
 import com.vmware.herald.sensor.datatype.Data;

--- a/herald/src/main/java/com/vmware/herald/sensor/payload/simple/ContactKey.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/payload/simple/ContactKey.java
@@ -1,3 +1,7 @@
+//  Copyright 2020 VMware, Inc.
+//  SPDX-License-Identifier: Apache-2.0
+//
+
 package com.vmware.herald.sensor.payload.simple;
 
 import com.vmware.herald.sensor.datatype.Data;

--- a/herald/src/main/java/com/vmware/herald/sensor/payload/simple/ContactKeySeed.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/payload/simple/ContactKeySeed.java
@@ -1,3 +1,7 @@
+//  Copyright 2020 VMware, Inc.
+//  SPDX-License-Identifier: Apache-2.0
+//
+
 package com.vmware.herald.sensor.payload.simple;
 
 import com.vmware.herald.sensor.datatype.Data;

--- a/herald/src/main/java/com/vmware/herald/sensor/payload/simple/F.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/payload/simple/F.java
@@ -1,3 +1,7 @@
+//  Copyright 2020 VMware, Inc.
+//  SPDX-License-Identifier: Apache-2.0
+//
+
 package com.vmware.herald.sensor.payload.simple;
 
 import com.vmware.herald.sensor.data.ConcreteSensorLogger;

--- a/herald/src/main/java/com/vmware/herald/sensor/payload/simple/K.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/payload/simple/K.java
@@ -1,3 +1,7 @@
+//  Copyright 2020 VMware, Inc.
+//  SPDX-License-Identifier: Apache-2.0
+//
+
 package com.vmware.herald.sensor.payload.simple;
 
 import com.vmware.herald.sensor.datatype.TimeInterval;

--- a/herald/src/main/java/com/vmware/herald/sensor/payload/simple/MatchingKey.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/payload/simple/MatchingKey.java
@@ -1,3 +1,7 @@
+//  Copyright 2020 VMware, Inc.
+//  SPDX-License-Identifier: Apache-2.0
+//
+
 package com.vmware.herald.sensor.payload.simple;
 
 import com.vmware.herald.sensor.datatype.Data;

--- a/herald/src/main/java/com/vmware/herald/sensor/payload/simple/MatchingKeySeed.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/payload/simple/MatchingKeySeed.java
@@ -1,3 +1,7 @@
+//  Copyright 2020 VMware, Inc.
+//  SPDX-License-Identifier: Apache-2.0
+//
+
 package com.vmware.herald.sensor.payload.simple;
 
 import com.vmware.herald.sensor.datatype.Data;

--- a/herald/src/main/java/com/vmware/herald/sensor/payload/simple/SecretKey.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/payload/simple/SecretKey.java
@@ -1,3 +1,7 @@
+//  Copyright 2020 VMware, Inc.
+//  SPDX-License-Identifier: Apache-2.0
+//
+
 package com.vmware.herald.sensor.payload.simple;
 
 import com.vmware.herald.sensor.datatype.Data;

--- a/herald/src/main/java/com/vmware/herald/sensor/payload/simple/SimplePayloadDataSupplier.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/payload/simple/SimplePayloadDataSupplier.java
@@ -1,3 +1,7 @@
+//  Copyright 2020 VMware, Inc.
+//  SPDX-License-Identifier: Apache-2.0
+//
+
 package com.vmware.herald.sensor.payload.simple;
 
 import com.vmware.herald.sensor.PayloadDataSupplier;

--- a/herald/src/main/java/com/vmware/herald/sensor/payload/sonar/SonarPayloadDataSupplier.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/payload/sonar/SonarPayloadDataSupplier.java
@@ -1,5 +1,5 @@
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 package com.vmware.herald.sensor.payload.sonar;

--- a/herald/src/main/java/com/vmware/herald/sensor/service/ForegroundService.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/service/ForegroundService.java
@@ -1,3 +1,7 @@
+//  Copyright 2020 VMware, Inc.
+//  SPDX-License-Identifier: Apache-2.0
+//
+
 package com.vmware.herald.sensor.service;
 
 import android.app.Notification;

--- a/herald/src/main/java/com/vmware/herald/sensor/service/NotificationService.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/service/NotificationService.java
@@ -1,3 +1,7 @@
+//  Copyright 2020 VMware, Inc.
+//  SPDX-License-Identifier: Apache-2.0
+//
+
 package com.vmware.herald.sensor.service;
 
 import android.app.Application;

--- a/herald/src/test/java/com/vmware/herald/sensor/analysis/InteractionsTests.java
+++ b/herald/src/test/java/com/vmware/herald/sensor/analysis/InteractionsTests.java
@@ -1,5 +1,5 @@
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 package com.vmware.herald.sensor.analysis;

--- a/herald/src/test/java/com/vmware/herald/sensor/analysis/SocialDistanceTests.java
+++ b/herald/src/test/java/com/vmware/herald/sensor/analysis/SocialDistanceTests.java
@@ -1,5 +1,5 @@
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 package com.vmware.herald.sensor.analysis;

--- a/herald/src/test/java/com/vmware/herald/sensor/ble/AdvertParserTests.java
+++ b/herald/src/test/java/com/vmware/herald/sensor/ble/AdvertParserTests.java
@@ -1,5 +1,5 @@
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 package com.vmware.herald.sensor.ble;

--- a/herald/src/test/java/com/vmware/herald/sensor/ble/filter/BLEDeviceFilterTest.java
+++ b/herald/src/test/java/com/vmware/herald/sensor/ble/filter/BLEDeviceFilterTest.java
@@ -1,5 +1,5 @@
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 package com.vmware.herald.sensor.ble.filter;

--- a/herald/src/test/java/com/vmware/herald/sensor/datatype/PayloadDataTests.java
+++ b/herald/src/test/java/com/vmware/herald/sensor/datatype/PayloadDataTests.java
@@ -1,3 +1,7 @@
+//  Copyright 2020 VMware, Inc.
+//  SPDX-License-Identifier: Apache-2.0
+//
+
 package com.vmware.herald.sensor.datatype;
 
 import org.junit.Test;

--- a/herald/src/test/java/com/vmware/herald/sensor/payload/simple/SimplePayloadDataSupplierTests.java
+++ b/herald/src/test/java/com/vmware/herald/sensor/payload/simple/SimplePayloadDataSupplierTests.java
@@ -1,5 +1,5 @@
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 package com.vmware.herald.sensor.payload.simple;


### PR DESCRIPTION
Changed license to Apache-2.0
- Also added license to files where it was missing
- Completed a clean, full rebuild, and ran tests successfully
Signed-off-by: Adam Fowler <adamfowleruk@gmail.com>