### PR TITLE
Fixes #51. Rename GPSSensor to AwakeSensor

### DIFF
--- a/app/src/main/java/com/vmware/herald/app/AppDelegate.java
+++ b/app/src/main/java/com/vmware/herald/app/AppDelegate.java
@@ -99,7 +99,7 @@ public class AppDelegate extends Application implements SensorDelegate {
 
     @Override
     public void sensor(SensorType sensor, Location didVisit) {
-        Log.i(tag, sensor.name() + ",didVisit=" + didVisit.description());
+        Log.i(tag, sensor.name() + ",didVisit=" + ((null == didVisit) ? "" : didVisit.description()));
     }
 
     @Override

--- a/herald/src/main/java/com/vmware/herald/sensor/datatype/SensorType.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/datatype/SensorType.java
@@ -8,10 +8,16 @@ package com.vmware.herald.sensor.datatype;
 public enum SensorType {
     /// Bluetooth Low Energy (BLE)
     BLE,
-    /// GPS location sensor
-    GPS
-//    /// Physical beacon, e.g. iBeacon
-//    BEACON,
-//    /// Ultrasound audio beacon.
-//    ULTRASOUND
+    /// Bluetooth Mesh
+    BLMESH,
+    /// Awake Sensor - Used on iOS
+    AWAKE,
+    /// GPS location sensor - Not used in Herald by default
+    GPS,
+    /// Physical beacon, e.g. iBeacon
+    BEACON,
+    /// Ultrasound audio beacon.
+    ULTRASOUND,
+    /// Other - in case of new sensor types in use between major versions
+    OTHER
 }


### PR DESCRIPTION
Rename GPSSensor to AwakeSensor
- No GPSSensor on Android to rename
- Brought SensorType constants in line with iOS API
- Allowed didVisit in sensor delegate callback to be null (AppDelegate callback)
Signed-off-by: Adam Fowler <adamfowleruk@gmail.com>