### PR TITLE
Event time interval logger - Validated

### DIFF
--- a/herald/src/main/java/com/vmware/herald/sensor/SensorArray.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/SensorArray.java
@@ -15,7 +15,7 @@ import com.vmware.herald.sensor.data.ConcreteSensorLogger;
 import com.vmware.herald.sensor.data.ContactLog;
 import com.vmware.herald.sensor.data.DetectionLog;
 import com.vmware.herald.sensor.data.SensorLogger;
-import com.vmware.herald.sensor.data.StatisticsDidReadLog;
+import com.vmware.herald.sensor.data.EventTimeIntervalLog;
 import com.vmware.herald.sensor.data.StatisticsLog;
 import com.vmware.herald.sensor.datatype.Data;
 import com.vmware.herald.sensor.datatype.PayloadData;
@@ -60,7 +60,7 @@ public class SensorArray implements Sensor {
 		if (BuildConfig.DEBUG) {
 	        add(new ContactLog(context, "contacts.csv"));
 	        add(new StatisticsLog(context, "statistics.csv", payloadData));
-	        add(new StatisticsDidReadLog(context, "statistics_didRead.csv", payloadData));
+	        add(new EventTimeIntervalLog(context, "eventRead.csv", payloadData, EventTimeIntervalLog.EventType.read));
 	        add(new DetectionLog(context,"detection.csv", payloadData));
 	        new BatteryLog(context, "battery.csv");
 		}

--- a/herald/src/main/java/com/vmware/herald/sensor/ble/BLESensorConfiguration.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/ble/BLESensorConfiguration.java
@@ -121,11 +121,12 @@ public class BLESensorConfiguration {
     /// - Remember to include ^ to match from start of message
     /// - Use deviceFilterTrainingEnabled in development environment to identify patterns
     public static String[] deviceFilterFeaturePatterns = new String[]{
+            "^00","^03","^05","^06","^07","^08","^09","^0B","^0C","^0D","^0E","^0F",
             "^10....04",
             "^10....14",
             "^10....1C",
-            "^05","^07","^09",
-            "^00","^01","^1002","^06","^08","^03","^0C","^0D","^0F","^0E","^0B"
+            "^1002",
+            "^0101000000000000000000000000000000"
     };
 }
 

--- a/herald/src/main/java/com/vmware/herald/sensor/data/EventTimeIntervalLog.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/data/EventTimeIntervalLog.java
@@ -7,8 +7,10 @@ package com.vmware.herald.sensor.data;
 import android.content.Context;
 
 import com.vmware.herald.sensor.DefaultSensorDelegate;
+import com.vmware.herald.sensor.datatype.Location;
 import com.vmware.herald.sensor.datatype.PayloadData;
 import com.vmware.herald.sensor.analysis.Sample;
+import com.vmware.herald.sensor.datatype.Proximity;
 import com.vmware.herald.sensor.datatype.SensorType;
 import com.vmware.herald.sensor.datatype.TargetIdentifier;
 
@@ -19,16 +21,22 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-/// CSV log of didRead calls for post event analysis and visualisation
-public class StatisticsDidReadLog extends DefaultSensorDelegate {
+/// CSV log of event time intervals for post event analysis and visualisation
+public class EventTimeIntervalLog extends DefaultSensorDelegate {
     private final TextFile textFile;
     private final PayloadData payloadData;
+    private final EventType eventType;
+    private final Map<TargetIdentifier, String> targetIdentifierToPayload = new ConcurrentHashMap<>();
     private final Map<String, Date> payloadToTime = new ConcurrentHashMap<>();
     private final Map<String, Sample> payloadToSample = new ConcurrentHashMap<>();
+    public  enum EventType {
+        detect,read,measure,share,sharedPeer,locate
+    }
 
-    public StatisticsDidReadLog(final Context context, final String filename, final PayloadData payloadData) {
-        textFile = new TextFile(context, filename);
+    public EventTimeIntervalLog(final Context context, final String filename, final PayloadData payloadData, final EventType eventType) {
+        this.textFile = new TextFile(context, filename);
         this.payloadData = payloadData;
+        this.eventType = eventType;
     }
 
     private String csv(String value) {
@@ -50,8 +58,10 @@ public class StatisticsDidReadLog extends DefaultSensorDelegate {
     }
 
     private void write() {
-        final StringBuilder content = new StringBuilder("payload,count,mean,sd,min,max\n");
+        final StringBuilder content = new StringBuilder("event,central,peripheral,count,mean,sd,min,max\n");
         final List<String> payloadList = new ArrayList<>();
+        final String event = csv(eventType.name());
+        final String centralPayload = csv(payloadData.shortName());
         for (String payload : payloadToSample.keySet()) {
             if (payload.equals(payloadData.shortName())) {
                 continue;
@@ -67,6 +77,10 @@ public class StatisticsDidReadLog extends DefaultSensorDelegate {
             if (sample.mean() == null || sample.standardDeviation() == null || sample.min() == null || sample.max() == null) {
                 continue;
             }
+            content.append(event);
+            content.append(',');
+            content.append(centralPayload);
+            content.append(',');
             content.append(csv(payload));
             content.append(',');
             content.append(sample.count());
@@ -88,13 +102,62 @@ public class StatisticsDidReadLog extends DefaultSensorDelegate {
 
     @Override
     public void sensor(SensorType sensor, PayloadData didRead, TargetIdentifier fromTarget) {
-        add(didRead.shortName());
+        final String payload = didRead.shortName();
+        targetIdentifierToPayload.put(fromTarget, payload);
+        if (eventType == EventType.read) {
+            add(payload);
+        }
+    }
+
+    @Override
+    public void sensor(SensorType sensor, TargetIdentifier didDetect) {
+        if (eventType == EventType.detect) {
+            final String payload = targetIdentifierToPayload.get(didDetect);
+            if (payload == null) {
+                return;
+            }
+            add(payload);
+        }
+    }
+
+    @Override
+    public void sensor(SensorType sensor, Proximity didMeasure, TargetIdentifier fromTarget) {
+        if (eventType == EventType.measure) {
+            final String payload = targetIdentifierToPayload.get(fromTarget);
+            if (payload == null) {
+                return;
+            }
+            add(payload);
+        }
     }
 
     @Override
     public void sensor(SensorType sensor, List<PayloadData> didShare, TargetIdentifier fromTarget) {
-        for (PayloadData payload : didShare) {
-            add(payload.shortName());
+        if (eventType == EventType.share) {
+            final String payload = targetIdentifierToPayload.get(fromTarget);
+            if (payload == null) {
+                return;
+            }
+            add(payload);
+        } else if (eventType == EventType.sharedPeer) {
+            for (final PayloadData sharedPeer : didShare) {
+                final String payload = sharedPeer.shortName();
+                if (payload == null) {
+                    return;
+                }
+                add(payload);
+            }
+        }
+    }
+
+    @Override
+    public void sensor(SensorType sensor, Location didVisit) {
+        if (eventType == EventType.locate) {
+            final String payload = payloadData.shortName();
+            if (payload == null) {
+                return;
+            }
+            add(payload);
         }
     }
 }


### PR DESCRIPTION
- Replaced limited didRead specific logger with general event time interval logger
- Supports detect, read, measure, share, sharedPeer, and locate events
- Output CSV file includes event, central(self), periphearl(target), and summary statistics
- Tested on Samsung A10, A20

- Rearranged filtering rules to alphanumeric and specificity order
- Replaced overly general ^01 rule with specific rule

Closes #71 

Signed-off-by: c19x <support@c19x.org>