### PR TITLE
UI acceleration - Validated

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,5 +1,23 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
+    <JetCodeStyleSettings>
+      <option name="PACKAGES_TO_USE_STAR_IMPORTS">
+        <value>
+          <package name="java.util" alias="false" withSubpackages="false" />
+          <package name="kotlinx.android.synthetic" alias="false" withSubpackages="true" />
+          <package name="io.ktor" alias="false" withSubpackages="true" />
+        </value>
+      </option>
+      <option name="PACKAGES_IMPORT_LAYOUT">
+        <value>
+          <package name="" alias="false" withSubpackages="true" />
+          <package name="java" alias="false" withSubpackages="true" />
+          <package name="javax" alias="false" withSubpackages="true" />
+          <package name="kotlin" alias="false" withSubpackages="true" />
+          <package name="" alias="true" withSubpackages="true" />
+        </value>
+      </option>
+    </JetCodeStyleSettings>
     <codeStyleSettings language="XML">
       <indentOptions>
         <option name="CONTINUATION_INDENT_SIZE" value="4" />

--- a/app/src/main/java/com/vmware/herald/app/MainActivity.java
+++ b/app/src/main/java/com/vmware/herald/app/MainActivity.java
@@ -54,6 +54,7 @@ public class MainActivity extends AppCompatActivity implements SensorDelegate, A
     private final static int permissionRequestCode = 1249951875;
     /// Test UI specific data, not required for production solution.
     private final static SimpleDateFormat dateFormatter = new SimpleDateFormat("YYYY-MM-dd HH:mm:ss");
+    private boolean foreground = false;
 
     // MARK:- Events
     private long didDetect = 0, didRead = 0, didMeasure = 0, didShare = 0, didReceive = 0;
@@ -219,19 +220,46 @@ public class MainActivity extends AppCompatActivity implements SensorDelegate, A
         updateSocialDistance(socialMixingScoreUnit);
     }
 
+    private void updateCounts() {
+        ((TextView) findViewById(R.id.didDetectCount)).setText(Long.toString(this.didDetect));
+        ((TextView) findViewById(R.id.didReadCount)).setText(Long.toString(this.didRead));
+        ((TextView) findViewById(R.id.didMeasureCount)).setText(Long.toString(this.didMeasure));
+        ((TextView) findViewById(R.id.didShareCount)).setText(Long.toString(this.didShare));
+        ((TextView) findViewById(R.id.didReceiveCount)).setText(Long.toString(this.didReceive));
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+        foreground = true;
+        Log.d(tag, "app (state=foreground)");
+        updateCounts();
+        updateTargets();
+        updateSocialDistance(socialMixingScoreUnit);
+    }
+
+    @Override
+    protected void onPause() {
+        foreground = false;
+        Log.d(tag, "app (state=background)");
+        super.onPause();
+    }
+
     // MARK:- SensorDelegate
 
     @Override
     public void sensor(SensorType sensor, TargetIdentifier didDetect) {
         this.didDetect++;
-        final String text = Long.toString(this.didDetect);
-        runOnUiThread(new Runnable() {
-            @Override
-            public void run() {
-                final TextView textView = findViewById(R.id.didDetectCount);
-                textView.setText(text);
-            }
-        });
+        if (foreground) {
+            final String text = Long.toString(this.didDetect);
+            runOnUiThread(new Runnable() {
+                @Override
+                public void run() {
+                    final TextView textView = findViewById(R.id.didDetectCount);
+                    textView.setText(text);
+                }
+            });
+        }
     }
 
     @Override
@@ -244,15 +272,17 @@ public class MainActivity extends AppCompatActivity implements SensorDelegate, A
         } else {
             payloads.put(didRead, new Target(fromTarget, didRead));
         }
-        final String text = Long.toString(this.didRead);
-        runOnUiThread(new Runnable() {
-            @Override
-            public void run() {
-                final TextView textView = findViewById(R.id.didReadCount);
-                textView.setText(text);
-                updateTargets();
-            }
-        });
+        if (foreground) {
+            final String text = Long.toString(this.didRead);
+            runOnUiThread(new Runnable() {
+                @Override
+                public void run() {
+                    final TextView textView = findViewById(R.id.didReadCount);
+                    textView.setText(text);
+                    updateTargets();
+                }
+            });
+        }
     }
 
     @Override
@@ -268,15 +298,17 @@ public class MainActivity extends AppCompatActivity implements SensorDelegate, A
                 payloads.put(didRead, new Target(fromTarget, didRead));
             }
         }
-        final String text = Long.toString(this.didShare);
-        runOnUiThread(new Runnable() {
-            @Override
-            public void run() {
-                final TextView textView = findViewById(R.id.didShareCount);
-                textView.setText(text);
-                updateTargets();
-            }
-        });
+        if (foreground) {
+            final String text = Long.toString(this.didShare);
+            runOnUiThread(new Runnable() {
+                @Override
+                public void run() {
+                    final TextView textView = findViewById(R.id.didShareCount);
+                    textView.setText(text);
+                    updateTargets();
+                }
+            });
+        }
     }
 
     @Override
@@ -290,16 +322,18 @@ public class MainActivity extends AppCompatActivity implements SensorDelegate, A
                 target.proximity(didMeasure);
             }
         }
-        final String text = Long.toString(this.didMeasure);
-        runOnUiThread(new Runnable() {
-            @Override
-            public void run() {
-                final TextView textView = findViewById(R.id.didMeasureCount);
-                textView.setText(text);
-                updateTargets();
-                updateSocialDistance(socialMixingScoreUnit);
-            }
-        });
+        if (foreground) {
+            final String text = Long.toString(this.didMeasure);
+            runOnUiThread(new Runnable() {
+                @Override
+                public void run() {
+                    final TextView textView = findViewById(R.id.didMeasureCount);
+                    textView.setText(text);
+                    updateTargets();
+                    updateSocialDistance(socialMixingScoreUnit);
+                }
+            });
+        }
     }
 
     @Override
@@ -314,15 +348,17 @@ public class MainActivity extends AppCompatActivity implements SensorDelegate, A
                 target.received(didReceive);
             }
         }
-        final String text = Long.toString(this.didReceive);
-        runOnUiThread(new Runnable() {
-            @Override
-            public void run() {
-                final TextView textView = findViewById(R.id.didReceiveCount);
-                textView.setText(text);
-                updateTargets();
-            }
-        });
+        if (foreground) {
+            final String text = Long.toString(this.didReceive);
+            runOnUiThread(new Runnable() {
+                @Override
+                public void run() {
+                    final TextView textView = findViewById(R.id.didReceiveCount);
+                    textView.setText(text);
+                    updateTargets();
+                }
+            });
+        }
     }
 
     @Override


### PR DESCRIPTION
Demo app UI update accelerates RSSI measurements by reducing demo UI overhead to better reflect actual HERALD library performance in production environments.
- Average time interval between RSSI update reduced from 1.71s down to 1.49s in 5 device test (3 Android + 2 iOS) over 24 hours.
- Continuity increased from 94.69% to 99.86%.

Details:
- Demo app UI updated to detected app in foreground/background mode
- UI is only updated in foreground mode, and on resume to minimise redundant work during tests
- Change motivated by experiments showing RSSI measurement rate when app logging is switched off is faster than UI thread, i.e. UI thread became bottleneck
- Test results for updated UI code show average time interval between RSSI update is now 1.49s in a test involving 3 Android + 2 iOS devices
- Same test before update shows average time interval is 1.71s with the same devices under the same test conditions.
- Validated with Pixel 2, Samsung A10, Samsung A20, iPhone 6S, iPhone 6 Plus over 24hr

Closes #96 

Signed-off-by: c19x <support@c19x.org>