### PR TITLE
Fixes #98. Allows javadoc generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,4 @@
 .externalNativeBuild
 .cxx
 git-template
-
+herald/javadoc

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -3,18 +3,9 @@
     <JetCodeStyleSettings>
       <option name="PACKAGES_TO_USE_STAR_IMPORTS">
         <value>
-          <package name="java.util" alias="false" withSubpackages="false" />
-          <package name="kotlinx.android.synthetic" alias="false" withSubpackages="true" />
-          <package name="io.ktor" alias="false" withSubpackages="true" />
-        </value>
-      </option>
-      <option name="PACKAGES_IMPORT_LAYOUT">
-        <value>
-          <package name="" alias="false" withSubpackages="true" />
-          <package name="java" alias="false" withSubpackages="true" />
-          <package name="javax" alias="false" withSubpackages="true" />
-          <package name="kotlin" alias="false" withSubpackages="true" />
-          <package name="" alias="true" withSubpackages="true" />
+          <package name="java.util" withSubpackages="false" static="false" />
+          <package name="kotlinx.android.synthetic" withSubpackages="true" static="false" />
+          <package name="io.ktor" withSubpackages="true" static="false" />
         </value>
       </option>
     </JetCodeStyleSettings>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="JavadocGenerationManager">
+    <option name="OUTPUT_DIRECTORY" value="$PROJECT_DIR$/build/javadoc" />
+  </component>
   <component name="NullableNotNullManager">
     <option name="myDefaultNullable" value="org.jetbrains.annotations.Nullable" />
     <option name="myDefaultNotNull" value="androidx.annotation.RecentlyNonNull" />

--- a/herald/build.gradle
+++ b/herald/build.gradle
@@ -114,3 +114,28 @@ afterEvaluate {
         }
     }
 }
+
+task javadoc(type: Javadoc) {
+
+    doFirst {
+        configurations.implementation
+                .filter { it.name.endsWith('.aar') }
+        .each { aar ->
+            copy {
+                from zipTree(aar)
+                include "**/classes.jar"
+                into "$buildDir/tmp/aarsToJars/${aar.name.replace('.aar', '')}/"
+            }
+        }
+    }
+
+    configurations.implementation.setCanBeResolved(true)
+    source = android.sourceSets.main.java.srcDirs
+    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
+    classpath += configurations.implementation
+    classpath += fileTree(dir: "$buildDir/tmp/aarsToJars/")
+    destinationDir = file("${project.buildDir}/outputs/javadoc/")
+    failOnError false
+    exclude '**/BuildConfig.java'
+    exclude '**/R.java'
+}

--- a/herald/src/main/java/com/vmware/herald/sensor/SensorArray.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/SensorArray.java
@@ -8,7 +8,6 @@ import android.content.Context;
 import android.content.Intent;
 import android.os.Build;
 
-import com.vmware.herald.BuildConfig;
 import com.vmware.herald.sensor.ble.ConcreteBLESensor;
 import com.vmware.herald.sensor.data.BatteryLog;
 import com.vmware.herald.sensor.data.ConcreteSensorLogger;
@@ -57,7 +56,7 @@ public class SensorArray implements Sensor {
 
         // Loggers
         payloadData = payloadDataSupplier.payload(new PayloadTimestamp());
-		if (BuildConfig.DEBUG) {
+		if (com.vmware.herald.BuildConfig.DEBUG) {
 	        add(new ContactLog(context, "contacts.csv"));
 	        add(new StatisticsLog(context, "statistics.csv", payloadData));
 	        add(new StatisticsDidReadLog(context, "statistics_didRead.csv", payloadData));

--- a/herald/src/main/java/com/vmware/herald/sensor/service/NotificationService.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/service/NotificationService.java
@@ -16,7 +16,6 @@ import android.os.Build;
 import androidx.core.app.NotificationCompat;
 import androidx.core.app.NotificationManagerCompat;
 
-import com.vmware.herald.R;
 import com.vmware.herald.sensor.datatype.Triple;
 import com.vmware.herald.sensor.datatype.Tuple;
 
@@ -63,7 +62,7 @@ public class NotificationService {
                 intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
                 final PendingIntent pendingIntent = PendingIntent.getActivity(context, 0, intent, 0);
                 final NotificationCompat.Builder builder = new NotificationCompat.Builder(context, notificationChannelName)
-                        .setSmallIcon(R.drawable.ic_notification)
+                        .setSmallIcon(com.vmware.herald.R.drawable.ic_notification)
                         .setContentTitle(title)
                         .setContentText(body)
                         .setContentIntent(pendingIntent)


### PR DESCRIPTION
Fixes #98. Allows javadoc generation
- Builds docs in to herald/javadoc
- Added folder to git ignore file
- Docs added to website
Signed-off-by: Adam Fowler <adamfowleruk@gmail.com>