### PR TITLE
Potential workaround for Exynos gatt server implementation

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -3,18 +3,9 @@
     <JetCodeStyleSettings>
       <option name="PACKAGES_TO_USE_STAR_IMPORTS">
         <value>
-          <package name="java.util" alias="false" withSubpackages="false" />
-          <package name="kotlinx.android.synthetic" alias="false" withSubpackages="true" />
-          <package name="io.ktor" alias="false" withSubpackages="true" />
-        </value>
-      </option>
-      <option name="PACKAGES_IMPORT_LAYOUT">
-        <value>
-          <package name="" alias="false" withSubpackages="true" />
-          <package name="java" alias="false" withSubpackages="true" />
-          <package name="javax" alias="false" withSubpackages="true" />
-          <package name="kotlin" alias="false" withSubpackages="true" />
-          <package name="" alias="true" withSubpackages="true" />
+          <package name="java.util" withSubpackages="false" static="false" />
+          <package name="kotlinx.android.synthetic" withSubpackages="true" static="false" />
+          <package name="io.ktor" withSubpackages="true" static="false" />
         </value>
       </option>
     </JetCodeStyleSettings>

--- a/herald/src/main/java/com/vmware/herald/sensor/ble/ConcreteBLETransmitter.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/ble/ConcreteBLETransmitter.java
@@ -104,19 +104,24 @@ public class ConcreteBLETransmitter implements BLETransmitter, BluetoothStateMan
     private BluetoothLeAdvertiser bluetoothLeAdvertiser() {
         final BluetoothAdapter bluetoothAdapter = BluetoothAdapter.getDefaultAdapter();
         if (bluetoothAdapter == null) {
-            //logger.fault("Bluetooth adapter unavailable");
+            logger.debug("bluetoothLeAdvertiser, no Bluetooth Adapter available");
             return null;
         }
-        if (!bluetoothAdapter.isMultipleAdvertisementSupported()) {
-            //logger.fault("Bluetooth advertisement unsupported");
+        boolean supported = bluetoothAdapter.isMultipleAdvertisementSupported();
+        try {
+            final BluetoothLeAdvertiser bluetoothLeAdvertiser = bluetoothAdapter.getBluetoothLeAdvertiser();
+            if (bluetoothLeAdvertiser == null) {
+                logger.debug("bluetoothLeAdvertiser, no LE advertiser present (multiSupported={}, exception=no)", supported);
+                return null;
+            }
+            // log this, as this will allow us to identify handsets with a different API implementation
+            logger.debug("bluetoothLeAdvertiser, LE advertiser present (multiSupported={})", supported);
+            return bluetoothLeAdvertiser;
+        } catch (Exception e) {
+            // log it, as this will allow us to identify handsets with the expected API implementation (from Android API source code)
+            logger.debug("bluetoothLeAdvertiser, no LE advertiser present (multiSupported={}, exception={})", supported, e.getMessage());
             return null;
         }
-        final BluetoothLeAdvertiser bluetoothLeAdvertiser = bluetoothAdapter.getBluetoothLeAdvertiser();
-        if (bluetoothLeAdvertiser == null) {
-            //logger.fault("Bluetooth advertisement unavailable");
-            return null;
-        }
-        return bluetoothLeAdvertiser;
     }
 
     private class AdvertLoopTask implements BLETimerDelegate {


### PR DESCRIPTION
Related to #107. Potential workaround for Exynos gatt server implementation
- Existing gattServer instances on devices with the Exynos base chipset do not remove adverts from the same source app
- Affects Exynos version of some Samsung handsets, but not the more prevalent SnapDragon versions
- Only causes an issue in testing if Bluetooth is turned on/off 23 times - a rare occurrence in normal usage
- Without the fix Herald would still allow an affected device to interact with other devices (iOS and Android) thanks to the 'calling card' / write characteristic
- Does not cause an issue for detection unless write characteristic/calling card is disabled (Not done in the Herald code base or library)
- Issue #110 also occurs on Exynos based handsets only
- Committing to develop to allow third party ISV testing today
Signed-off-by: Adam Fowler <adamfowleruk@gmail.com>
