### PR TITLE
Transmitter stop simplification

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -3,9 +3,18 @@
     <JetCodeStyleSettings>
       <option name="PACKAGES_TO_USE_STAR_IMPORTS">
         <value>
-          <package name="java.util" withSubpackages="false" static="false" />
-          <package name="kotlinx.android.synthetic" withSubpackages="true" static="false" />
-          <package name="io.ktor" withSubpackages="true" static="false" />
+          <package name="java.util" alias="false" withSubpackages="false" />
+          <package name="kotlinx.android.synthetic" alias="false" withSubpackages="true" />
+          <package name="io.ktor" alias="false" withSubpackages="true" />
+        </value>
+      </option>
+      <option name="PACKAGES_IMPORT_LAYOUT">
+        <value>
+          <package name="" alias="false" withSubpackages="true" />
+          <package name="java" alias="false" withSubpackages="true" />
+          <package name="javax" alias="false" withSubpackages="true" />
+          <package name="kotlin" alias="false" withSubpackages="true" />
+          <package name="" alias="true" withSubpackages="true" />
         </value>
       </option>
     </JetCodeStyleSettings>


### PR DESCRIPTION
- Using the same function for stopping advert, when triggered by internal timer and external events
- Stop advert function makes best effort for graceful stop where possible
- Using stop advert function (instead of bluetoothGattServer=null) following BluetoothState==PowerOff is not expected to offer any benefit, but it is certainly harmless, and enables logging of this previously unseen condition for investigation
- Tested on Pixel 2 (Android 29), J6 (Android 28), with iPhone 6s (iOS 12.1.4)

- Also tested impact of many rapid Bluetooth ON/OFF on Pixel 2, Android will enter an intermittent BLE fault state where:
   - the UI and BLE state becomes out of sync (BLE is OFF in logs, but UI shows its ON, which may or may not synchronise again over time);
   - BLE fails to start again (BLE is manually set to ON, then becomes OFF again on its own); or
   - BLE appears to be ON but is non-functional (BLE appears to be ON, but scan returns nothing). 
   - All of the above conditions have been observed even without HERALD being installed.

Closes #122 
Closes #107

Signed-off-by: c19x <support@c19x.org>