### PR TITLE
Motion sensing and logging - Validated

### DIFF
--- a/herald/src/main/java/com/vmware/herald/sensor/SensorArray.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/SensorArray.java
@@ -11,6 +11,7 @@ import android.os.Build;
 import com.vmware.herald.sensor.ble.BLESensorConfiguration;
 import com.vmware.herald.sensor.ble.ConcreteBLESensor;
 import com.vmware.herald.sensor.data.BatteryLog;
+import com.vmware.herald.sensor.data.CalibrationLog;
 import com.vmware.herald.sensor.data.ConcreteSensorLogger;
 import com.vmware.herald.sensor.data.ContactLog;
 import com.vmware.herald.sensor.data.DetectionLog;
@@ -22,6 +23,7 @@ import com.vmware.herald.sensor.datatype.PayloadData;
 import com.vmware.herald.sensor.datatype.PayloadTimestamp;
 import com.vmware.herald.sensor.datatype.TargetIdentifier;
 import com.vmware.herald.sensor.datatype.TimeInterval;
+import com.vmware.herald.sensor.motion.ConcreteInertiaSensor;
 import com.vmware.herald.sensor.service.ForegroundService;
 
 import java.util.ArrayList;
@@ -55,6 +57,12 @@ public class SensorArray implements Sensor {
         // Define sensor array
         concreteBleSensor = new ConcreteBLESensor(context, payloadDataSupplier);
         sensorArray.add(concreteBleSensor);
+        // Inertia sensor configured for automated RSSI-distance calibration data capture
+        if (BLESensorConfiguration.inertiaSensorEnabled != null) {
+            logger.debug("Inertia sensor enabled (threshold={})", BLESensorConfiguration.inertiaSensorEnabled);
+            sensorArray.add(new ConcreteInertiaSensor(context, BLESensorConfiguration.inertiaSensorEnabled));
+            add(new CalibrationLog(context, "calibration.csv"));
+        }
 
         // Loggers
         payloadData = payloadDataSupplier.payload(new PayloadTimestamp());

--- a/herald/src/main/java/com/vmware/herald/sensor/SensorArray.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/SensorArray.java
@@ -58,9 +58,9 @@ public class SensorArray implements Sensor {
         concreteBleSensor = new ConcreteBLESensor(context, payloadDataSupplier);
         sensorArray.add(concreteBleSensor);
         // Inertia sensor configured for automated RSSI-distance calibration data capture
-        if (BLESensorConfiguration.inertiaSensorEnabled != null) {
-            logger.debug("Inertia sensor enabled (threshold={})", BLESensorConfiguration.inertiaSensorEnabled);
-            sensorArray.add(new ConcreteInertiaSensor(context, BLESensorConfiguration.inertiaSensorEnabled));
+        if (BLESensorConfiguration.inertiaSensorEnabled) {
+            logger.debug("Inertia sensor enabled");
+            sensorArray.add(new ConcreteInertiaSensor(context));
             add(new CalibrationLog(context, "calibration.csv"));
         }
 

--- a/herald/src/main/java/com/vmware/herald/sensor/ble/BLESensorConfiguration.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/ble/BLESensorConfiguration.java
@@ -138,10 +138,9 @@ public class BLESensorConfiguration {
     /// Enable inertia sensor and set threshold
     /// - Inertia sensor (accelerometer) measures acceleration in meters per second (m/s) along device X, Y and Z axis
     /// - Generates SensorDelegate:didVisit callbacks with InertiaLocationReference data
-    /// - Set to null to disable sensor, and non-null value to enable sensor and define reporting threshold
-    /// - Reporting threshold is magnitude of acceleration in m/s along any direction
+    /// - Set to false to disable sensor, and true value to enable sensor
     /// - This is used for automated capture of RSSI at different distances, where the didVisit data is used as markers
-    public static Double inertiaSensorEnabled = null;
+    public static boolean inertiaSensorEnabled = false;
 }
 
 

--- a/herald/src/main/java/com/vmware/herald/sensor/ble/BLESensorConfiguration.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/ble/BLESensorConfiguration.java
@@ -135,7 +135,7 @@ public class BLESensorConfiguration {
             "^00","^1002","^06","^08","^03","^0C","^0D","^0F","^0E","^0B"
     };
 
-    /// Enable inertia sensor and set threshold
+    /// Enable inertia sensor
     /// - Inertia sensor (accelerometer) measures acceleration in meters per second (m/s) along device X, Y and Z axis
     /// - Generates SensorDelegate:didVisit callbacks with InertiaLocationReference data
     /// - Set to false to disable sensor, and true value to enable sensor

--- a/herald/src/main/java/com/vmware/herald/sensor/ble/BLESensorConfiguration.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/ble/BLESensorConfiguration.java
@@ -134,6 +134,14 @@ public class BLESensorConfiguration {
             "^05","^07","^09",
             "^00","^1002","^06","^08","^03","^0C","^0D","^0F","^0E","^0B"
     };
+
+    /// Enable inertia sensor and set threshold
+    /// - Inertia sensor (accelerometer) measures acceleration in meters per second (m/s) along device X, Y and Z axis
+    /// - Generates SensorDelegate:didVisit callbacks with InertiaLocationReference data
+    /// - Set to null to disable sensor, and non-null value to enable sensor and define reporting threshold
+    /// - Reporting threshold is magnitude of acceleration in m/s along any direction
+    /// - This is used for automated capture of RSSI at different distances, where the didVisit data is used as markers
+    public static Double inertiaSensorEnabled = null;
 }
 
 

--- a/herald/src/main/java/com/vmware/herald/sensor/data/CalibrationLog.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/data/CalibrationLog.java
@@ -1,0 +1,55 @@
+//  Copyright 2020 VMware, Inc.
+//  SPDX-License-Identifier: Apache-2.0
+//
+
+package com.vmware.herald.sensor.data;
+
+import android.content.Context;
+
+import com.vmware.herald.sensor.DefaultSensorDelegate;
+import com.vmware.herald.sensor.datatype.InertiaLocationReference;
+import com.vmware.herald.sensor.datatype.Location;
+import com.vmware.herald.sensor.datatype.PayloadData;
+import com.vmware.herald.sensor.datatype.Proximity;
+import com.vmware.herald.sensor.datatype.SensorType;
+import com.vmware.herald.sensor.datatype.TargetIdentifier;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.List;
+
+/// CSV contact log for post event analysis and visualisation
+public class CalibrationLog extends DefaultSensorDelegate {
+    private final static SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+    private final TextFile textFile;
+
+    public CalibrationLog(final Context context, final String filename) {
+        textFile = new TextFile(context, filename);
+        if (textFile.empty()) {
+            textFile.write("time,payload,rssi,movement");
+        }
+    }
+
+    private String timestamp() {
+        return dateFormatter.format(new Date());
+    }
+
+    private String csv(String value) {
+        return TextFile.csv(value);
+    }
+
+    // MARK:- SensorDelegate
+
+
+    @Override
+    public void sensor(SensorType sensor, Proximity didMeasure, TargetIdentifier fromTarget, PayloadData withPayload) {
+        textFile.write(timestamp() + "," + csv(withPayload.shortName()) + "," + didMeasure.value + ",");
+    }
+
+    @Override
+    public void sensor(SensorType sensor, Location didVisit) {
+        if (didVisit.value instanceof InertiaLocationReference) {
+            textFile.write(timestamp() + ",,," + ((InertiaLocationReference) didVisit.value).y);
+        }
+    }
+}

--- a/herald/src/main/java/com/vmware/herald/sensor/data/CalibrationLog.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/data/CalibrationLog.java
@@ -26,7 +26,7 @@ public class CalibrationLog extends DefaultSensorDelegate {
     public CalibrationLog(final Context context, final String filename) {
         textFile = new TextFile(context, filename);
         if (textFile.empty()) {
-            textFile.write("time,payload,rssi,movement");
+            textFile.write("time,payload,rssi,x,y,z");
         }
     }
 
@@ -43,13 +43,14 @@ public class CalibrationLog extends DefaultSensorDelegate {
 
     @Override
     public void sensor(SensorType sensor, Proximity didMeasure, TargetIdentifier fromTarget, PayloadData withPayload) {
-        textFile.write(timestamp() + "," + csv(withPayload.shortName()) + "," + didMeasure.value + ",");
+        textFile.write(timestamp() + "," + csv(withPayload.shortName()) + "," + didMeasure.value + ",,,");
     }
 
     @Override
     public void sensor(SensorType sensor, Location didVisit) {
         if (didVisit.value instanceof InertiaLocationReference) {
-            textFile.write(timestamp() + ",,," + ((InertiaLocationReference) didVisit.value).y);
+            final InertiaLocationReference reference = (InertiaLocationReference) didVisit.value;
+            textFile.write(timestamp() + ",,," + reference.x + ","  + reference.y + "," + reference.z);
         }
     }
 }

--- a/herald/src/main/java/com/vmware/herald/sensor/data/CalibrationLog.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/data/CalibrationLog.java
@@ -1,4 +1,4 @@
-//  Copyright 2020 VMware, Inc.
+//  Copyright 2021 VMware, Inc.
 //  SPDX-License-Identifier: Apache-2.0
 //
 
@@ -30,11 +30,11 @@ public class CalibrationLog extends DefaultSensorDelegate {
         }
     }
 
-    private String timestamp() {
+    private static String timestamp() {
         return dateFormatter.format(new Date());
     }
 
-    private String csv(String value) {
+    private static String csv(String value) {
         return TextFile.csv(value);
     }
 

--- a/herald/src/main/java/com/vmware/herald/sensor/datatype/InertiaLocationReference.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/datatype/InertiaLocationReference.java
@@ -1,4 +1,4 @@
-//  Copyright 2020 VMware, Inc.
+//  Copyright 2021 VMware, Inc.
 //  SPDX-License-Identifier: Apache-2.0
 //
 

--- a/herald/src/main/java/com/vmware/herald/sensor/datatype/InertiaLocationReference.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/datatype/InertiaLocationReference.java
@@ -1,0 +1,21 @@
+//  Copyright 2020 VMware, Inc.
+//  SPDX-License-Identifier: Apache-2.0
+//
+
+package com.vmware.herald.sensor.datatype;
+
+/// Acceleration (x,y,z) in meters per second at point in time
+public class InertiaLocationReference implements LocationReference {
+    public final double x, y, z, magnitude;
+
+    public InertiaLocationReference(Double x, Double y, Double z) {
+        this.x = (x == null ? 0 : x);
+        this.y = (y == null ? 0 : y);
+        this.z = (z == null ? 0 : z);
+        this.magnitude = Math.sqrt((this.x * this.x) + (this.y * this.y) + (this.z * this.z));
+    }
+
+    public String description() {
+        return "Inertia(magnitude=" + magnitude + ",x=" + x + ",y=" + y + ",z=" + z + ")";
+    }
+}

--- a/herald/src/main/java/com/vmware/herald/sensor/datatype/SensorType.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/datatype/SensorType.java
@@ -18,6 +18,8 @@ public enum SensorType {
     BEACON,
     /// Ultrasound audio beacon.
     ULTRASOUND,
+    /// Accelerometer motion sensor
+    ACCELEROMETER,
     /// Other - in case of new sensor types in use between major versions
     OTHER
 }

--- a/herald/src/main/java/com/vmware/herald/sensor/motion/ConcreteInertiaSensor.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/motion/ConcreteInertiaSensor.java
@@ -1,0 +1,110 @@
+//  Copyright 2020 VMware, Inc.
+//  SPDX-License-Identifier: Apache-2.0
+//
+
+package com.vmware.herald.sensor.motion;
+
+import android.content.Context;
+import android.hardware.Sensor;
+import android.hardware.SensorEvent;
+import android.hardware.SensorEventListener;
+import android.hardware.SensorManager;
+
+import com.vmware.herald.sensor.SensorDelegate;
+import com.vmware.herald.sensor.data.ConcreteSensorLogger;
+import com.vmware.herald.sensor.data.SensorLogger;
+import com.vmware.herald.sensor.datatype.InertiaLocationReference;
+import com.vmware.herald.sensor.datatype.Location;
+import com.vmware.herald.sensor.datatype.SensorType;
+
+import java.util.Date;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+public class ConcreteInertiaSensor implements InertiaSensor {
+    private final SensorLogger logger = new ConcreteSensorLogger("Sensor", "Motion.ConcreteInertiaSensor");
+    private final Queue<SensorDelegate> delegates = new ConcurrentLinkedQueue<>();
+    private final ExecutorService operationQueue = Executors.newSingleThreadExecutor();
+    private final Context context;
+    private final double threshold;
+    private final SensorEventListener sensorEventListener = new SensorEventListener() {
+        @Override
+        public void onSensorChanged(SensorEvent event) {
+            if (event.sensor.getType() != Sensor.TYPE_LINEAR_ACCELERATION) {
+                return;
+            }
+            try {
+                final Date timestamp = new Date();
+                final double x = event.values[0];
+                final double y = event.values[1];
+                final double z = event.values[2];
+                final InertiaLocationReference inertiaLocationReference = new InertiaLocationReference(x, y, z);
+                if (inertiaLocationReference.magnitude < threshold) {
+                    return;
+                }
+                final Location didVisit = new Location(inertiaLocationReference, timestamp, timestamp);
+                operationQueue.execute(new Runnable() {
+                    @Override
+                    public void run() {
+                        for (final SensorDelegate delegate : delegates) {
+                            delegate.sensor(SensorType.ACCELEROMETER, didVisit);
+                        }
+                    }
+                });
+            } catch (Throwable e) {
+                logger.fault("onSensorChanged failed to get sensor data", e);
+                return;
+            }
+        }
+
+        @Override
+        public void onAccuracyChanged(Sensor sensor, int accuracy) {
+        }
+    };
+    private SensorManager sensorManager;
+    private Sensor hardwareSensor;
+
+    public ConcreteInertiaSensor(final Context context, final double threshold) {
+        this.context = context;
+        this.threshold = threshold;
+    }
+
+    @Override
+    public void add(SensorDelegate delegate) {
+        delegates.add(delegate);
+    }
+
+    @Override
+    public void start() {
+        // Get sensor manager
+        if (sensorManager == null) {
+            this.sensorManager = (SensorManager) context.getSystemService(Context.SENSOR_SERVICE);
+        }
+        if (sensorManager == null) {
+            logger.fault("start, sensor manager unavailable");
+            return;
+        }
+        // Get hardware sensor
+        if (hardwareSensor == null) {
+            hardwareSensor = sensorManager.getDefaultSensor(Sensor.TYPE_LINEAR_ACCELERATION);
+        }
+        if (hardwareSensor == null) {
+            logger.fault("start, inertia sensor unavailable");
+            return;
+        }
+        // Register listener
+        sensorManager.unregisterListener(sensorEventListener);
+        sensorManager.registerListener(sensorEventListener, hardwareSensor, SensorManager.SENSOR_DELAY_NORMAL);
+    }
+
+    @Override
+    public void stop() {
+        if (sensorManager == null) {
+            logger.fault("stop, sensor manager unavailable");
+            return;
+        }
+        sensorManager.unregisterListener(sensorEventListener);
+    }
+}

--- a/herald/src/main/java/com/vmware/herald/sensor/motion/InertiaSensor.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/motion/InertiaSensor.java
@@ -1,0 +1,10 @@
+//  Copyright 2020 VMware, Inc.
+//  SPDX-License-Identifier: Apache-2.0
+//
+
+package com.vmware.herald.sensor.motion;
+
+import com.vmware.herald.sensor.Sensor;
+
+public interface InertiaSensor extends Sensor {
+}

--- a/herald/src/main/java/com/vmware/herald/sensor/motion/InertiaSensor.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/motion/InertiaSensor.java
@@ -1,4 +1,4 @@
-//  Copyright 2020 VMware, Inc.
+//  Copyright 2021 VMware, Inc.
 //  SPDX-License-Identifier: Apache-2.0
 //
 

--- a/herald/src/test/java/com/vmware/herald/sensor/datatype/LocationReferenceTests.java
+++ b/herald/src/test/java/com/vmware/herald/sensor/datatype/LocationReferenceTests.java
@@ -59,5 +59,9 @@ public class LocationReferenceTests {
         assertEquals(3.464, (double) new InertiaLocationReference(2d, 2d, 2d).magnitude, 0.001);
         assertNotNull(new InertiaLocationReference(null, null, null).description());
         assertNotNull(new InertiaLocationReference(2d, 2d, 2d).description());
+        assertNotNull(new InertiaLocationReference(Double.MAX_VALUE, Double.MAX_VALUE, Double.MAX_VALUE).description());
+        assertNotNull(new InertiaLocationReference(-Double.MAX_VALUE, -Double.MAX_VALUE, -Double.MAX_VALUE).description());
+        assertEquals(Double.POSITIVE_INFINITY, (double) new InertiaLocationReference(Double.MAX_VALUE, Double.MAX_VALUE, Double.MAX_VALUE).magnitude, 0.001);
+        assertEquals(Double.POSITIVE_INFINITY, (double) new InertiaLocationReference(-Double.MAX_VALUE, -Double.MAX_VALUE, -Double.MAX_VALUE).magnitude, 0.001);
     }
 }

--- a/herald/src/test/java/com/vmware/herald/sensor/datatype/LocationReferenceTests.java
+++ b/herald/src/test/java/com/vmware/herald/sensor/datatype/LocationReferenceTests.java
@@ -46,4 +46,18 @@ public class LocationReferenceTests {
         assertNotNull(new WGS84PointLocationReference(null, null, null).description());
         assertNotNull(new WGS84PointLocationReference(1d, 2d, 3d).description());
     }
+
+    @Test
+    public void testInertiaLocationReference() {
+        assertEquals(0, (double) new InertiaLocationReference(null, null, null).x, Double.MIN_VALUE);
+        assertEquals(0, (double) new InertiaLocationReference(null, null, null).y, Double.MIN_VALUE);
+        assertEquals(0, (double) new InertiaLocationReference(null, null, null).z, Double.MIN_VALUE);
+        assertEquals(0, (double) new InertiaLocationReference(null, null, null).magnitude, Double.MIN_VALUE);
+        assertEquals(1, (double) new InertiaLocationReference(1d, null, null).x, Double.MIN_VALUE);
+        assertEquals(2, (double) new InertiaLocationReference(null, 2d, null).y, Double.MIN_VALUE);
+        assertEquals(3, (double) new InertiaLocationReference(null, null, 3d).z, Double.MIN_VALUE);
+        assertEquals(3.464, (double) new InertiaLocationReference(2d, 2d, 2d).magnitude, 0.001);
+        assertNotNull(new InertiaLocationReference(null, null, null).description());
+        assertNotNull(new InertiaLocationReference(2d, 2d, 2d).description());
+    }
 }


### PR DESCRIPTION
- Enables motion sensing with accelerometer
- Generates SensorDelegate callbacks for didVisit, where the location reference is a relative reference based on inertia
- Tested on Pixel2 (with iPhone 6S) for automated RSSI-distance data capture
- Motion data used as timed markers for detecting movement at fixed distances

Signed-off-by: c19x <support@c19x.org>