### PR TITLE
Legacy payload capture - Validated

### DIFF
--- a/herald/src/main/java/com/vmware/herald/sensor/ble/BLESensorConfiguration.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/ble/BLESensorConfiguration.java
@@ -7,6 +7,7 @@ package com.vmware.herald.sensor.ble;
 import android.bluetooth.BluetoothGattCharacteristic;
 
 import com.vmware.herald.sensor.data.SensorLoggerLevel;
+import com.vmware.herald.sensor.datatype.Data;
 import com.vmware.herald.sensor.datatype.RandomSource;
 import com.vmware.herald.sensor.datatype.TimeInterval;
 
@@ -32,11 +33,30 @@ public class BLESensorConfiguration {
     /// Primary payload characteristic (read) for distributing payload data from peripheral to central, e.g. identity data
     /// - Characteristic UUID is randomly generated V4 UUIDs that has been tested for uniqueness by conducting web searches to ensure it returns no results.
     public final static UUID payloadCharacteristicUUID = UUID.fromString("3e98c0f8-8f05-4829-a121-43e38f8933e7");
+
+    // MARK:- Support for legacy BLE services
+
 	/// Legacy payload sharing characteristic
+    /// - Enable support for capturing of legacy read/write based protocol
+    /// - Set UUID to null to disable feature
+    /// - Example protocol is TT service that reads and writes payload via a GATT characteristic
+    /// ---- Herald will read from this characteristic to obtain legacy payload
+    /// ---- Data written to this characteristic by legacy protocol will be captured by Herald
 	public static UUID legacyPayloadCharacteristicUUID = null;
-	/// A full characteristic description itself for a legacy payload
 	public static BluetoothGattCharacteristic legacyPayloadCharacteristic = null;
-	
+	/// Legacy advert only protocol service
+    /// - Enable support for capturing of legacy advert only protocols
+    /// - Assumes protocol advertises a service UUID and boardcasts token data in service data area
+    /// - Set UUID to null to disable feature
+    /// - Example protocol is EN service that uses a 16-bit UUID and data key 0xFD6F
+    /// --- Scan for 16-bit UUID by setting the value xxxx in base UUID 0000xxxx-0000-1000-8000-00805F9B34FB
+    /// --- Read broadcasted token data from service data area associated with given data key "FD6F"
+    ///     legacyAdvertOnlyProtocolServiceUUID = UUID.fromString("0000FD6F-0000-1000-8000-00805F9B34FB");
+    ///     legacyAdvertOnlyProtocolServiceUUIDDataKey = Data.fromHexEncodedString("FD6F");
+    public static UUID legacyAdvertOnlyProtocolServiceUUID = null;
+    public static Data legacyAdvertOnlyProtocolServiceUUIDDataKey = null;
+
+
     /// Standard Bluetooth service and characteristics
     /// These are all fixed UUID from the BLE standard.
     /// Standard Bluetooth Service UUID for Generic Access Service

--- a/herald/src/main/java/com/vmware/herald/sensor/ble/ConcreteBLETransmitter.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/ble/ConcreteBLETransmitter.java
@@ -582,7 +582,7 @@ public class ConcreteBLETransmitter implements BLETransmitter, BluetoothStateMan
                 BluetoothGattCharacteristic.PROPERTY_READ,
                 BluetoothGattCharacteristic.PERMISSION_READ);
         service.addCharacteristic(signalCharacteristic);
-		if (null != BLESensorConfiguration.legacyPayloadCharacteristic) {
+		if (BLESensorConfiguration.legacyPayloadCharacteristic != null) {
 			final BluetoothGattCharacteristic legacyPayloadCharacteristic = 
 			BLESensorConfiguration.legacyPayloadCharacteristic;
         	service.addCharacteristic(legacyPayloadCharacteristic);

--- a/herald/src/main/java/com/vmware/herald/sensor/ble/filter/BLEAdvertParser.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/ble/filter/BLEAdvertParser.java
@@ -159,4 +159,21 @@ public class BLEAdvertParser {
         }
         return appleSegments;
     }
+
+    public static List<BLEAdvertServiceData> extractServiceUUID16Data(List<BLEAdvertSegment> segments) {
+        // find the serviceData code segment in the list
+        List<BLEAdvertServiceData> serviceData = new ArrayList<>();
+        for (BLEAdvertSegment segment : segments) {
+            if (segment.type == BLEAdvertSegmentType.serviceUUID16Data) {
+                // Ensure that the data area is long enough
+                if (segment.data.length < 2) {
+                    continue; // there may be a valid segment of same type... Happens for manufacturer data
+                }
+                // Create a service data segment
+                final byte[] serviceUUID16LittleEndian = subDataLittleEndian(segment.data,0,2);
+                serviceData.add(new BLEAdvertServiceData(serviceUUID16LittleEndian, subDataBigEndian(segment.data,2,segment.dataLength - 2), segment.raw));
+            }
+        }
+        return serviceData;
+    }
 }

--- a/herald/src/main/java/com/vmware/herald/sensor/ble/filter/BLEAdvertSegmentType.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/ble/filter/BLEAdvertSegmentType.java
@@ -24,6 +24,7 @@ public enum BLEAdvertSegmentType {
     simplePairingHash("simplePairingHash",0x0E),
     simplePairingRandomiser("simplePairingRandomiser",0x0F),
     deviceID("deviceID",0x10),
+    serviceUUID16Data("serviceUUID16Data", 0x16),
     meshMessage("meshMessage",0x2A),
     meshBeacon("meshBeacon",0x2B),
     bigInfo("bigInfo",0x2C),

--- a/herald/src/main/java/com/vmware/herald/sensor/ble/filter/BLEAdvertServiceData.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/ble/filter/BLEAdvertServiceData.java
@@ -1,0 +1,28 @@
+//  Copyright 2021 VMware, Inc.
+//  SPDX-License-Identifier: Apache-2.0
+//
+
+package com.vmware.herald.sensor.ble.filter;
+
+import com.vmware.herald.sensor.datatype.Data;
+
+public class BLEAdvertServiceData {
+    public final byte[] service;
+    public final byte[] data; // BIG ENDIAN (network order) AT THIS POINT
+    public final Data raw;
+
+    public BLEAdvertServiceData(final byte[] service, final byte[] dataBigEndian, final Data raw) {
+        this.service = service;
+        this.data = dataBigEndian;
+        this.raw = raw;
+    }
+
+    @Override
+    public String toString() {
+        return "BLEAdvertServiceData{" +
+                "service=" + new Data(service).hexEncodedString() +
+                ", data=" + new Data(data).hexEncodedString() +
+                ", raw=" + raw.hexEncodedString() +
+                '}';
+    }
+}

--- a/herald/src/main/java/com/vmware/herald/sensor/datatype/LegacyPayloadData.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/datatype/LegacyPayloadData.java
@@ -1,0 +1,23 @@
+//  Copyright 2020 VMware, Inc.
+//  SPDX-License-Identifier: Apache-2.0
+//
+
+package com.vmware.herald.sensor.datatype;
+
+import java.util.UUID;
+
+/// Legacy payload data received from target
+public class LegacyPayloadData extends PayloadData {
+    public final UUID service;
+
+    public LegacyPayloadData(final UUID service, final byte[] value) {
+        super(value);
+        this.service = service;
+    }
+
+    /// Suffix :L for legacy payloads
+    @Override
+    public String shortName() {
+        return super.shortName() + ":L";
+    }
+}


### PR DESCRIPTION
- Enables payload capture from legacy advert only protocols where payload data is broadcasted in advert service data area
- Validated on Samsung A10 (Android 28), A20 (Android 29) with iPhone X (iOS 14.2) and 6S (iOS 12.1.4)
- Test confirms A10 captures both Herald and Legacy payloads from A20 and iPhone X
- Normal operation for Herald protocol across all test phones

Closes #132

Signed-off-by: c19x <support@c19x.org>